### PR TITLE
Update crytic-compile version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
-    "crytic-compile",
+    "crytic-compile >= 0.3.0",
     "z3-solver",
 ]
 dynamic = ["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-crytic-compile
+crytic-compile >= 0.3.0
 z3-solver

--- a/src/symtest/__main__.py
+++ b/src/symtest/__main__.py
@@ -335,6 +335,8 @@ def main() -> int:
     total_failed = 0
 
     for filename, contracts_names in compilation_unit.filename_to_contracts.items():
+        source_unit = compilation_unit.source_units[filename]
+
         if args.contract:
             if args.contract not in contracts_names: continue
             contracts = [args.contract]
@@ -342,11 +344,11 @@ def main() -> int:
             contracts = list(contracts_names)
 
         for contract in contracts:
-            hexcode = compilation_unit.bytecodes_runtime[contract]
-            srcmap = compilation_unit.srcmaps_runtime[contract]
+            hexcode = source_unit.bytecodes_runtime[contract]
+            srcmap = source_unit.srcmaps_runtime[contract]
             srcs = []
-            abi = compilation_unit.abis[contract]
-            methodIdentifiers = compilation_unit.hashes(contract)
+            abi = source_unit.abis[contract]
+            methodIdentifiers = source_unit.hashes(contract)
 
             funsigs = [funsig for funsig in methodIdentifiers if funsig.startswith(args.function)]
 


### PR DESCRIPTION
Update to crytic-compile [v0.3.0](https://github.com/crytic/crytic-compile/releases/tag/0.3.0).

Now the minimum version required is 0.3.0, due to the API breaking change of splitting CompilationUnit into CompilationUnit + SourceUnit.
