### PR TITLE
Improve loop unrolling

### DIFF
--- a/tests/src/Counter.sol
+++ b/tests/src/Counter.sol
@@ -26,9 +26,38 @@ contract Counter {
         }
     }
 
-    function loop(uint n) public {
+    function loopFor(uint n) public {
         for (uint i; i < n; i++) {
             cnt++;
+        }
+    }
+
+    function loopWhile(uint n) public {
+        uint i = 0;
+        while (i < n) {
+            cnt++;
+            i++;
+        }
+    }
+
+    function loopDoWhile(uint n) public {
+        uint i = 0;
+        do {
+            cnt++;
+        } while (++i < n);
+    }
+
+    function loopConst() public {
+        for (uint i; i < 4; i++) {
+            cnt++;
+        }
+    }
+
+    mapping (uint => bool) map;
+    function loopConstIf() public {
+        // total # of paths is 16 (= 2^4), but only 6 (= 4C2) of them will be considered if `--loop 2` is given
+        for (uint i; i < 4; i++) {
+            if (map[i]) cnt++;
         }
     }
 

--- a/tests/test/Counter.t.sol
+++ b/tests/test/Counter.t.sol
@@ -30,14 +30,49 @@ contract CounterTest is Counter {
         assert(cnt < oldCnt || cnt == oldCnt + n); // cnt >= oldCnt ==> cnt == oldCnt + n
     }
 
-    function specLoop(uint n) public {
+    function specLoopFor(uint n) public {
         uint oldCnt = cnt;
-        loop(n);
+        loopFor(n);
         assert(cnt >= oldCnt);
         assert(cnt == oldCnt + n);
     }
-    function testLoop(uint8 k) public {
-        specLoop(k);
+    function testLoopFor(uint8 k) public {
+        specLoopFor(k);
+    }
+
+    function specLoopWhile(uint n) public {
+        uint oldCnt = cnt;
+        loopWhile(n);
+        assert(cnt >= oldCnt);
+        assert(cnt == oldCnt + n);
+    }
+    function testLoopWhile(uint8 k) public {
+        specLoopWhile(k);
+    }
+
+    function specLoopDoWhile(uint n) public {
+        uint oldCnt = cnt;
+        loopDoWhile(n);
+        assert(cnt > oldCnt);
+        if (n == 0) assert(cnt == oldCnt + 1);
+        else assert(cnt == oldCnt + n);
+    }
+    function testLoopDoWhile(uint8 k) public {
+        specLoopDoWhile(k);
+    }
+
+    function testLoopConst() public {
+        uint oldCnt = cnt;
+        loopConst();
+        assert(cnt >= oldCnt);
+        assert(cnt == oldCnt + 4);
+    }
+
+    function testLoopConstIf() public {
+        uint oldCnt = cnt;
+        loopConstIf();
+        assert(cnt >= oldCnt);
+        assert(cnt <= oldCnt + 4);
     }
 
     function specSetSum(uint[2] memory arr) public {


### PR DESCRIPTION
This implements a new loop unrolling mechanism which adds supports for:
- do-while loops
- constant-bounded loops

Within each function scope, the new mechanism:
1. limits the number of repeated execution of `JUMPI` (instead of `JUMP`) to the bound given by `--loop`,
2. except those whose condition is solved to either true or false, but not both.

Note:
- (1) is needed because the do-while loop doesn't involve `JUMP`.
- (2) is needed to support constant-bounded loops (e.g., see the `loopConst()` function).
- Regarding the function scope, we mean the functions at the bytecode level, including the compiler-generated functions that don't appear in the source code.

Limitation:
(1) cannot distinguish between if-branching and loop back-edges. Thus if a constant-bounded loop has if-branches in the body, then each branch can be repeated only up to a given loop unrolling value. Due to this, some loop iteration paths could be missed if the given unrolling value is smaller than the loop (constant) bound.

