### PR TITLE
Fix SMOD encoding

### DIFF
--- a/src/symtest/sevm.py
+++ b/src/symtest/sevm.py
@@ -455,7 +455,7 @@ class SEVM:
                 return f_sdiv(w1, w2)
         elif op == 'SMOD':
             if w1.decl().name() == 'bv' and w2.decl().name() == 'bv':
-                return w1 % w2
+                return SRem(w1, w2) # bvsrem  # vs: w1 % w2 (bvsmod w1 w2)
             else:
                 return f_smod(w1, w2)
         elif op == 'EXP':


### PR DESCRIPTION
Fix the SMT encoding for SMOD.  The `SMOD` opcode semantics is equivalent to `bvsrem`, not `bvsmod`, in the bitvector theory.

`SMOD x y` and `bvsrem x y` first compute the remainder of `abs(x) / abs(y)`, and put the sign of `x` to the result. That is, they choose the remainder that has the same sign of `x`. For example:
```
SMOD  4  3 ==  1
SMOD  4 -3 ==  1
SMOD -4  3 == -1
SMOD -4 -3 == -1
```

```
bvsrem  4  3 ==  1    (simplify (bvsrem #b0100 #b0011))
bvsrem  4 -3 ==  1    (simplify (bvsrem #b0100 #b1101))
bvsrem -4  3 == -1    (simplify (bvsrem #b1100 #b0011))
bvsrem -4 -3 == -1    (simplify (bvsrem #b1100 #b1101))
```

On the other hand, `bvsmod x y` chooses the remainder that has the same sign with `y`.

```
bvsmod  4  3 ==  1    (simplify (bvsmod #b0100 #b0011))
bvsmod  4 -3 == -2    (simplify (bvsmod #b0100 #b1101))
bvsmod -4  3 ==  2    (simplify (bvsmod #b1100 #b0011))
bvsmod -4 -3 == -1    (simplify (bvsmod #b1100 #b1101))
```