### PR TITLE
Improve nonlinear reasoning

### DIFF
--- a/tests/test/Counter.t.sol
+++ b/tests/test/Counter.t.sol
@@ -90,12 +90,28 @@ contract CounterTest is Counter {
         assert(cnt == oldCnt + bytes(s).length + bytes(r).length);
     }
 
-    function testDiv1(uint x, uint y) public {
-        assert(y == 0 || x / y <= x);
+    function testDiv1(uint x, uint y) public pure {
+        if (y > 0) {
+            assert(x / y <= x);
+        }
     }
 
-    function testDiv2(uint x, uint y) public {
-        assert(x / y == x / y);
+    function testDiv2(uint x, uint y) public pure {
+        if (y > 0) {
+            assert(x / y == x / y);
+        }
+    }
+
+    function testMulDiv(uint x, uint y) public pure {
+        unchecked {
+            if (x > 0 && y > 0) {
+                uint z = x * y;
+                if (z / x == y) {
+                    assert(z / x == y);
+                  //assert(z / y == x); // smt failed to solve
+                }
+            }
+        }
     }
 
     function testFail() public pure {


### PR DESCRIPTION
Improve nonlinear arithmetic reasoning a bit:
- suppress invalid counterexamples due to uninterpreted function abstraction for nonlinear arithmetic operators
- rerun smt solver with additional axiomatizations when invalid counterexamples are generated