### PR TITLE
Do not ignore unsupported cheatcode

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -232,7 +232,7 @@ def run(
             print(f'# {idx+1} / {len(exs)}')
             print(ex)
     for opcode, idx, ex in stuck:
-        print(color_warn('Not supported: ' + opcode))
+        print(color_warn('Not supported: ' + opcode + ' ' + ex.error))
         if args.verbose >= 1:
             print(f'# {idx+1} / {len(exs)}')
             print(ex)

--- a/tests/test/Foundry.t.sol
+++ b/tests/test/Foundry.t.sol
@@ -12,4 +12,8 @@ contract FoundryTest is Test {
         vm.assume(x < 10);
         assertLt(x, 100);
     }
+
+    function testPrank(address x) public {
+        vm.prank(x); // not supported
+    }
 }


### PR DESCRIPTION
Halmos currently abstracts all external calls as uninterpreted (which doesn't miss real bugs but may report false positives), but this behavior was not suitable for unsupported cheat codes. Now it stops execution when encountering unsupported cheat codes.