### PR TITLE
Support setUp() test patterns

### DIFF
--- a/examples/src/Example.sol
+++ b/examples/src/Example.sol
@@ -29,7 +29,7 @@ contract Example {
 
     function isPowerOfTwoIter(uint x) public pure returns (bool) {
         unchecked {
-            while (x != 0 && (x & 1) == 0) x >>= 1;
+            while (x != 0 && (x & 1) == 0) x >>= 1; // NOTE: `--loop 256` option needed for complete verification
             return x == 1;
         }
     }

--- a/examples/test/Example.t.sol
+++ b/examples/test/Example.t.sol
@@ -30,7 +30,7 @@ contract ExampleTest is Example {
     function testIsPowerOfTwo(uint256 x) public pure {
         bool result1 = isPowerOfTwo(x);
         bool result2 = false;
-        for (uint i = 0; i < 256; i++) {
+        for (uint i = 0; i < 256; i++) { // NOTE: `--loop 256` option needed for complete verification
             if (x == 2**i) {
                 result2 = true;
                 break;

--- a/tests/src/Counter.sol
+++ b/tests/src/Counter.sol
@@ -68,4 +68,16 @@ contract Counter {
     function setString(string memory s) public {
         cnt += bytes(s).length;
     }
+
+    function foo(uint a, uint b, uint c, uint d) public {
+        bar(a);
+        bar(b);
+        bar(c);
+        bar(d);
+    }
+
+    function bar(uint x) public {
+        if (x > 10) cnt++;
+        else cnt++;
+    }
 }

--- a/tests/src/Create.sol
+++ b/tests/src/Create.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+contract Create {
+    uint public value;
+    uint public immutable halmos;
+
+    constructor(uint qed) {
+        halmos = qed;
+    }
+
+    function set(uint x) public {
+        value = x;
+    }
+}

--- a/tests/test/Counter.t.sol
+++ b/tests/test/Counter.t.sol
@@ -90,6 +90,12 @@ contract CounterTest is Counter {
         assert(cnt == oldCnt + bytes(s).length + bytes(r).length);
     }
 
+    function testFoo(uint a, uint b, uint c, uint d) public {
+        uint oldCnt = cnt;
+        foo(a, b, c, d);
+        assert(cnt == oldCnt + 4);
+    }
+
     function testDiv1(uint x, uint y) public pure {
         if (y > 0) {
             assert(x / y <= x);

--- a/tests/test/Create.t.sol
+++ b/tests/test/Create.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+import "../src/Create.sol";
+
+contract CreateTest is Test {
+    Create public create;
+
+    function setUp() public {
+        create = new Create(0x220E);
+    }
+
+    function testSet(uint x) public {
+        create.set(x);
+        assertEq(create.value(), x);
+        assertEq(create.halmos(), 0x220E);
+    }
+}


### PR DESCRIPTION
This adds support for common Foundry test patterns using setUp().

If setUp() function exists, Halmos now executes it first, followed by each test function. This can be used to create the target contract that can be referred to by the test functions. Note that Halmos also allows you to create a test contract that directly inherits the target contract.

By default, the storage variables of contracts created by setUp() are initialized with a symbolic value, instead of a zero value, unless they are explicitly assigned to a specific value. This makes it easy to run test functions with a symbolic storage that represents arbitrary storage states.

