### PR TITLE
Improve counterexample output

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -297,7 +297,7 @@ def run(
     print(f"{passfail} {funsig} (paths: {normal}/{len(exs)}, time: {end - start:0.2f}s, bounds: [{', '.join(dyn_param_size)}])")
     for model, idx, ex in models:
         if model:
-            print(color_warn('Counterexample: ' + str(model)))
+            print(color_warn('Counterexample: ' + str_model(model, args)))
         else:
             print(color_warn('Counterexample: unknown'))
         if args.verbose >= 1:
@@ -373,6 +373,18 @@ def is_valid_model(model) -> bool:
         if str(decl).startswith('evm_'):
             return False
     return True
+
+def str_model(model, args: argparse.Namespace) -> str:
+    def select(var):
+        name = str(var)
+        if name.startswith('p_'): return True
+        elif args.verbose >= 1:
+            if name.startswith('storage') or name.startswith('msg_') or name.startswith('this_'): return True
+        return False
+    if args.debug:
+        return str(model)
+    else:
+        return '[' + ', '.join(sorted(map(lambda decl: f'{decl} = {model[decl]}', filter(select, model)))) + ']'
 
 def main() -> int:
     #

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -317,8 +317,7 @@ class Exec: # an execution path
             # when len(args) >= 2
             args = loc.children()
             if len(args) < 2: raise ValueError(loc)
-            args = list(map(self.decode_storage_loc, args))
-            args.sort(key=lambda x: len(x), reverse=True)
+            args = sorted(map(self.decode_storage_loc, args), key=lambda x: len(x), reverse=True)
             if len(args[1]) > 1: raise ValueError(loc) # only args[0]'s length >= 1, the others must be 1
             return args[0][0:-1] + (reduce(lambda r, x: r + x[0], args[1:], args[0][-1]),)
         elif is_bv_value(loc) and int(str(loc)) in sha3_inv:


### PR DESCRIPTION
- Print parameters only, by default
- Print storages, msg, this, if `-v` is given
- Print all, if `--debug` given