### PR TITLE
add pc parsing to sevm

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1214,6 +1214,9 @@ class SEVM:
                 #   ex.st.push(f_chainid())
                     ex.st.push(con(1)) # for ethereum
 
+                elif opcode == EVM.PC:
+                    ex.st.push(con(ex.pc))
+
                 elif opcode == EVM.BLOCKHASH:
                     ex.st.push(f_blockhash(ex.st.pop()))
 


### PR DESCRIPTION
Currently `halmos --bytecode 5800` (PC STOP) will cause a parsing error as PC isn't an option in `sevm/run()`

This is a simple change, adding `EVM.PC` as a parsing option in `sevm.py`.

Curious how you'd like to test this and similar situations. Solidity isn't kind to using pc:
![solidity_pc](https://user-images.githubusercontent.com/98172525/232872119-0b60f641-7f17-4bbf-b129-c3e5dc64f544.png)

I found this when I was compiling Huff and running halmos on it, though adding Huff support for testing may be overkill.

Would you be in favor of adding it in through `test_cli.py` or `test_sevm.py`?
```
def test_run_pc(args, options):
    hexcode = '5800'
    options['sym_jump'] = True
    exs = run_bytecode(hexcode, args, options)
    assert len(exs) == 1
    ex = exs[0]
    assert str(ex.pgm[ex.this][ex.pc].op[0]) == str(EVM.STOP)
```

