### PR TITLE
feat: no longer set default storage values to symbolic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
         run: pytest
 
       - name: Test Halmos
-        run: halmos tests
+        run: halmos tests --symbolic-storage

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -34,6 +34,7 @@ def parse_args(args) -> argparse.Namespace:
     parser.add_argument('--depth', metavar='MAX_DEPTH', type=int, help='set the max path length')
     parser.add_argument('--array-lengths', metavar='NAME1=LENGTH1,NAME2=LENGTH2,...', help='set the length of dynamic-sized arrays including bytes and string (default: loop unrolling bound)')
 
+    parser.add_argument('--symbolic-storage', action='store_true', help='set default storage values to symbolic')
     parser.add_argument('--symbolic-jump', action='store_true', help='support symbolic jump destination (experimental)')
 
     parser.add_argument('--no-smt-add',          action='store_true', help='do not interpret `+`')
@@ -202,7 +203,7 @@ def run_bytecode(hexcode: str, args: argparse.Namespace, options: Dict) -> List[
         callvalue = callvalue,
         caller    = caller,
         this      = this,
-        symbolic  = True,
+        symbolic  = args.symbolic_storage,
         solver    = solver,
     )
     (exs, _) = sevm.run(ex)
@@ -332,7 +333,7 @@ def run(
         st        = State(),
         jumpis    = {},
         output    = None,
-        symbolic  = True,
+        symbolic  = args.symbolic_storage,
         prank     = Prank(), # prank is reset after setUp()
         #
         solver    = solver,

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -565,7 +565,7 @@ def main() -> int:
                     num_failed = 0
                     print(f'\nRunning {len(funsigs)} tests for {filename.short}:{contract}')
 
-                    setup_sigs = sorted([ (k,v) for k,v in methodIdentifiers.items() if k == 'setUp()' or k.startswith('setUpPlus(') ])
+                    setup_sigs = sorted([ (k,v) for k,v in methodIdentifiers.items() if k == 'setUp()' or k.startswith('setUpSymbolic(') ])
                     (setup_name, setup_sig, setup_selector) = (None, None, None)
                     if len(setup_sigs) > 0:
                         (setup_sig, setup_selector) = setup_sigs[-1]

--- a/tests/test/SetupPlus.t.sol
+++ b/tests/test/SetupPlus.t.sol
@@ -18,19 +18,19 @@ contract SetupPlusTest {
         a = new A(11, 200);
     }
 
-    // if setUpPlus() is provided, Halmos uses setUpPlus() instead of setUp().
-    // setUpPlus() is symbolically executed.
+    // if setUpSymbolic() is provided, Halmos uses setUpSymbolic() instead of setUp().
+    // setUpSymbolic() is symbolically executed.
 
-    // if multiple setUpPlus() functions are provided, the last one in the lexicographical order will be used.
-    // e.g., setUpPlus(uint256,uint256) is used instead of setUpPlus(uint256).
+    // if multiple setUpSymbolic() functions are provided, the last one in the lexicographical order will be used.
+    // e.g., setUpSymbolic(uint256,uint256) is used instead of setUpSymbolic(uint256).
 
-    function setUpPlus(uint x, uint y) public {
+    function setUpSymbolic(uint x, uint y) public {
         require(x > 10);
         require(y > 100);
         a = new A(x, y);
     }
 
-    function setUpPlus(uint x) public {
+    function setUpSymbolic(uint x) public {
         a = new A(x, x);
     }
 
@@ -79,7 +79,7 @@ contract SetupPlusTestB {
         mk();
     }
 
-    function setUpPlus(uint[4] memory _init) public {
+    function setUpSymbolic(uint[4] memory _init) public {
         init[0] = _init[0];
         init[1] = _init[1];
         init[2] = _init[2];


### PR DESCRIPTION
Storage variables including mappings and dynamic arrays are no longer set to symbolic by default. Instead, they retain their initial value as set by the constructor or default to zero, until a symbolic value is explicitly assigned to them.

The symbolic setup method `setUpPlus()` is renamed to `setUpSymbolic()`.