### PR TITLE
Add support for PUSH0

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1392,6 +1392,9 @@ class SEVM:
                         keys.append(ex.st.pop())
                     ex.log.append((keys, wload(ex.st.memory, loc, size) if size > 0 else None))
 
+                elif opcode == EVM.PUSH0:
+                    ex.st.push(con(0))
+
                 elif EVM.PUSH1 <= opcode <= EVM.PUSH32:
                     if is_bv_value(o.op[1]):
                         val = int(str(o.op[1]))

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -74,6 +74,7 @@ class EVM:
     MSIZE          = 0x59
     GAS            = 0x5a
     JUMPDEST       = 0x5b
+    PUSH0          = 0x5f
     PUSH1          = 0x60
     PUSH2          = 0x61
     PUSH3          = 0x62
@@ -219,6 +220,7 @@ str_opcode: Dict[int, str] = {
     EVM.MSIZE          : 'MSIZE',
     EVM.GAS            : 'GAS',
     EVM.JUMPDEST       : 'JUMPDEST',
+    EVM.PUSH0          : 'PUSH0',
     EVM.PUSH1          : 'PUSH1',
     EVM.PUSH2          : 'PUSH2',
     EVM.PUSH3          : 'PUSH3',

--- a/tests/foundry.toml
+++ b/tests/foundry.toml
@@ -4,3 +4,5 @@ out = 'out'
 libs = ['lib']
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
+force = false
+evm_version = 'shanghai'

--- a/tests/test/Opcode.t.sol
+++ b/tests/test/Opcode.t.sol
@@ -46,4 +46,27 @@ contract OpcodeTest is Test {
         assertEq(result1, result2);
     }
 
+    function testPush0() public {
+        // target bytecode is 0x365f5f37365ff3
+        //  36 CALLDATASIZE
+        //  5F PUSH0
+        //  5F PUSH0
+        //  37 CALLDATACOPY -> copies calldata at mem[0..calldatasize]
+
+        //  36 CALLDATASIZE
+        //  5F PUSH0
+        //  F3 RETURN -> returns mem[0..calldatasize]
+
+        // a tiny deployer (that uses PUSH0), to deploy the above bytecode
+        uint256 deployCode = 0x66365f5f37365ff35f5260076019f3;
+        address target;
+        assembly {
+            mstore(0, deployCode)
+            target := create(/* value */ 0, /* offset */ 0x11, /* size */ 15)
+        }
+
+        (bool success, bytes memory result) = target.call(bytes("hello PUSH0"));
+        assertTrue(success);
+        assertEq(string(result), "hello PUSH0");
+    }
 }

--- a/tests/test_sevm.py
+++ b/tests/test_sevm.py
@@ -83,6 +83,7 @@ def test_run(hexcode, stack, pc, opcode, sevm, solver, storage):
     assert str(ex.pgm[ex.this][ex.pc].op[0]) == opcode
 
 @pytest.mark.parametrize('hexcode, params, output', [
+    (o(EVM.PUSH0), [], con(0)),
     (o(EVM.ADD), [x, y], x + y),
     (o(EVM.MUL), [x, y], x * y),
     (o(EVM.SUB), [x, y], x - y),


### PR DESCRIPTION
This effectively switches the supported EVM version to Shanghai, not sure if we want to explicitly support older versions (e.g. to model chains that don't support it).

This updates the evm_version in foundry.toml so that `forge test --match testPush0` returns the expected value.