### PR TITLE
feat: change default prefix of tests from `test` to `check`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
         run: pytest
 
       - name: Test Halmos
-        run: halmos tests --symbolic-storage
+        run: halmos tests --symbolic-storage --function test

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -25,7 +25,7 @@ def parse_args(args) -> argparse.Namespace:
 
     parser.add_argument('target', metavar='TARGET_DIRECTORY', nargs='?', default=os.getcwd(), help='source root directory (default: current directory)')
     parser.add_argument('--contract', metavar='CONTRACT_NAME', help='run tests in the given contract only')
-    parser.add_argument('--function', metavar='FUNCTION_NAME_PREFIX', default='test', help='run tests matching the given prefix only (default: %(default)s)')
+    parser.add_argument('--function', metavar='FUNCTION_NAME_PREFIX', default='check', help='run tests matching the given prefix only (default: %(default)s)')
 
     parser.add_argument('--bytecode', metavar='HEX_STRING', help='execute the given bytecode')
 


### PR DESCRIPTION
The default prefix for test functions is changed from `test` to `prove`. This change makes it easy to distinguish between symbolic tests and fuzz tests. Symbolic tests often require different cheatcodes or testing patterns, and this separation can improve the user experience. The previous behavior can be still achieved by having the `--function test` option.