### PR TITLE
feat: add vm.store(), load() cheatcode

### DIFF
--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -83,6 +83,9 @@ class hevm_cheat_code:
     # bytes4(keccak256("deal(address,uint256)"))
     deal_sig: int = 0xc88a5e6d
 
+    # bytes4(keccak256("store(address,bytes32,bytes32)"))
+    store_sig: int = 0x70ca10bb
+
     # bytes4(keccak256("fee(uint256)"))
     fee_sig: int = 0x39b37ab0
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -86,6 +86,9 @@ class hevm_cheat_code:
     # bytes4(keccak256("store(address,bytes32,bytes32)"))
     store_sig: int = 0x70ca10bb
 
+    # bytes4(keccak256("load(address,bytes32)"))
+    load_sig: int = 0x667f9d70
+
     # bytes4(keccak256("fee(uint256)"))
     fee_sig: int = 0x39b37ab0
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -876,6 +876,16 @@ class SEVM:
                         ex.error = f'uninitialized account: {store_account}'
                         out.append(ex)
                         return
+                # vm.load(address,bytes32)
+                elif eq(arg.sort(), BitVecSort((4+32*2)*8)) and simplify(Extract(543, 512, arg)) == hevm_cheat_code.load_sig:
+                    load_account = simplify(Extract(511, 256, arg))
+                    load_slot = simplify(Extract(255, 0, arg))
+                    if load_account in ex.storage:
+                        ret = ex.sload(load_account, load_slot)
+                    else:
+                        ex.error = f'uninitialized account: {load_account}'
+                        out.append(ex)
+                        return
                 # vm.fee(uint256)
                 elif eq(arg.sort(), BitVecSort((4+32)*8)) and simplify(Extract(287, 256, arg)) == hevm_cheat_code.fee_sig:
                     ex.block.basefee = simplify(Extract(255, 0, arg))

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -42,6 +42,12 @@ f_exp  = Function('evm_exp' , BitVecSort(256), BitVecSort(256), BitVecSort(256))
 def con(n: int) -> Word:
     return BitVecVal(n, 256)
 
+def int_of(x: Any, err: str) -> int:
+    if is_bv_value(x):
+        return x.as_long()
+    else:
+        raise NotImplementedError(f'{err}: {x}')
+
 def wextend(mem: List[Byte], loc: int, size: int) -> None:
     if len(mem) < loc + size:
         mem.extend([BitVecVal(0, 8) for _ in range(loc + size - len(mem))])
@@ -133,7 +139,7 @@ class State:
         self.stack[n] = tmp
 
     def mloc(self) -> int:
-        loc: int = int(str(self.pop())) # loc must be concrete
+        loc: int = int_of(self.pop(), 'symbolic memory offset')
         return loc
 
     def mstore(self, full: bool) -> None:
@@ -152,7 +158,7 @@ class State:
 
     def ret(self) -> Bytes:
         loc: int = self.mloc()
-        size: int = int(str(self.pop())) # size (in bytes) must be concrete
+        size: int = int_of(self.pop(), 'symbolic return data size') # size in bytes
         if size > 0:
             return wload(self.memory, loc, size)
         else:
@@ -326,7 +332,7 @@ class Exec: # an execution path
     def sload(self, loc: Word) -> Word:
         offsets = self.decode_storage_loc(loc)
         if not len(offsets) > 0: raise ValueError(offsets)
-        slot, keys = int(str(offsets[0])), offsets[1:]
+        slot, keys = int_of(offsets[0], 'symbolic storage base slot'), offsets[1:]
         self.sinit(slot, keys)
         if len(keys) == 0:
             return self.storage[self.this][slot][0]
@@ -336,7 +342,7 @@ class Exec: # an execution path
     def sstore(self, loc: Any, val: Any) -> None:
         offsets = self.decode_storage_loc(loc)
         if not len(offsets) > 0: raise ValueError(offsets)
-        slot, keys = int(str(offsets[0])), offsets[1:]
+        slot, keys = int_of(offsets[0], 'symbolic storage base slot'), offsets[1:]
         self.sinit(slot, keys)
         if len(keys) == 0:
             self.storage[self.this][slot][0] = val
@@ -398,7 +404,7 @@ class Exec: # an execution path
 
     def sha3(self) -> None:
         loc: int = self.st.mloc()
-        size: int = int(str(self.st.pop())) # size (in bytes) must be concrete
+        size: int = int_of(self.st.pop(), 'symbolic SHA3 data size')
         self.sha3_data(wload(self.st.memory, loc, size), size)
 
     def sha3_data(self, data: Bytes, size: int) -> None:
@@ -685,9 +691,9 @@ class SEVM:
         else:
             fund = ex.st.pop()
         arg_loc: int = ex.st.mloc()
-        arg_size: int = int(str(ex.st.pop())) # size (in bytes) must be concrete
+        arg_size: int = int_of(ex.st.pop(), 'symbolic CALL input data size') # size (in bytes)
         ret_loc: int = ex.st.mloc()
-        ret_size: int = int(str(ex.st.pop())) # size (in bytes) must be concrete
+        ret_size: int = int_of(ex.st.pop(), 'symbolic CALL return data size') # size (in bytes)
 
         if not arg_size >= 0: raise ValueError(arg_size)
         if not ret_size >= 0: raise ValueError(ret_size)
@@ -903,8 +909,8 @@ class SEVM:
 
     def create(self, ex: Exec, stack: List[Tuple[Exec,int]], step_id: int, out: List[Exec]) -> None:
         value: Word = ex.st.pop()
-        loc: int = int(str(ex.st.pop()))
-        size: int = int(str(ex.st.pop()))
+        loc: int = int_of(ex.st.pop(), 'symbolic CREATE offset')
+        size: int = int_of(ex.st.pop(), 'symbolic CREATE size')
 
         # contract creation code
         create_hexcode = wload(ex.st.memory, loc, size)
@@ -1008,7 +1014,7 @@ class SEVM:
         jid = ex.jumpi_id()
 
         source: int = ex.pc
-        target: int = int(str(ex.st.pop())) # target must be concrete
+        target: int = int_of(ex.st.pop(), 'symbolic JUMPI target')
         cond: Word = ex.st.pop()
 
         visited = ex.jumpis.get(jid, {True: 0, False: 0})
@@ -1066,7 +1072,7 @@ class SEVM:
                 ex.solver.pop()
 
         else:
-            raise ValueError(dst)
+            raise NotImplementedError(f'symbolic JUMP target: {dst}')
 
     def create_branch(self, ex: Exec, cond: str, target: int) -> Exec:
         new_solver = SolverFor('QF_AUFBV')
@@ -1231,10 +1237,7 @@ class SEVM:
                     ex.st.push(LShR(ex.st.pop(), w)) # bvlshr
 
                 elif opcode == EVM.SIGNEXTEND:
-                    w = ex.st.pop()
-                    if not is_bv_value(w): raise ValueError(w)
-
-                    w = int(str(w))
+                    w = int_of(ex.st.pop(), 'symbolic SIGNEXTEND size')
                     if w <= 30: # if w == 31, result is SignExt(0, value) == value
                         bl = (w + 1) * 8
                         ex.st.push(SignExt(256 - bl, Extract(bl - 1, 0, ex.st.pop())))
@@ -1246,7 +1249,7 @@ class SEVM:
                     if ex.calldata is None:
                         ex.st.push(f_calldataload(ex.st.pop()))
                     else:
-                        offset: int = int(str(ex.st.pop()))
+                        offset: int = int_of(ex.st.pop(), 'symbolic CALLDATALOAD offset')
                         ex.st.push(Concat((ex.calldata + [BitVecVal(0, 8)] * 32)[offset:offset+32]))
                     #   try:
                     #       offset: int = int(str(ex.st.pop()))
@@ -1345,14 +1348,14 @@ class SEVM:
                     ex.st.push(con(ex.returndatasize()))
                 elif opcode == EVM.RETURNDATACOPY:
                     loc: int = ex.st.mloc()
-                    offset: int = int(str(ex.st.pop())) # offset must be concrete
-                    size: int = int(str(ex.st.pop())) # size (in bytes) must be concrete
+                    offset: int = int_of(ex.st.pop(), 'symbolic RETURNDATACOPY offset')
+                    size: int = int_of(ex.st.pop(), 'symbolic RETURNDATACOPY size') # size (in bytes)
                     wstore_partial(ex.st.memory, loc, offset, size, ex.output, ex.returndatasize())
 
                 elif opcode == EVM.CALLDATACOPY:
                     loc: int = ex.st.mloc()
-                    offset: int = int(str(ex.st.pop())) # offset must be concrete
-                    size: int = int(str(ex.st.pop())) # size (in bytes) must be concrete
+                    offset: int = int_of(ex.st.pop(), 'symbolic CALLDATACOPY offset')
+                    size: int = int_of(ex.st.pop(), 'symbolic CALLDATACOPY size') # size (in bytes)
                     if size > 0:
                         if ex.calldata is None:
                             f_calldatacopy = Function('calldatacopy_'+str(size*8), BitVecSort(256), BitVecSort(size*8))
@@ -1368,14 +1371,14 @@ class SEVM:
 
                 elif opcode == EVM.CODECOPY:
                     loc: int = ex.st.mloc()
-                    pc: int = int(str(ex.st.pop())) # pc must be concrete
-                    size: int = int(str(ex.st.pop())) # size (in bytes) must be concrete
+                    pc: int = int_of(ex.st.pop(), 'symbolic CODECOPY offset')
+                    size: int = int_of(ex.st.pop(), 'symbolic CODECOPY size') # size (in bytes)
                     wextend(ex.st.memory, loc, size)
                     for i in range(size):
                         ex.st.memory[loc + i] = ex.read_code(pc + i)
 
                 elif opcode == EVM.BYTE:
-                    idx: int = int(str(ex.st.pop())) # index must be concrete
+                    idx: int = int_of(ex.st.pop(), 'symbolic BYTE offset')
                     if idx < 0: raise ValueError(idx)
                     w = ex.st.pop()
                     if idx >= 32:
@@ -1386,7 +1389,7 @@ class SEVM:
                 elif EVM.LOG0 <= opcode <= EVM.LOG4:
                     num_keys: int = opcode - EVM.LOG0
                     loc: int = ex.st.mloc()
-                    size: int = int(str(ex.st.pop())) # size (in bytes) must be concrete
+                    size: int = int_of(ex.st.pop(), 'symbolic LOG data size') # size (in bytes)
                     keys = []
                     for _ in range(num_keys):
                         keys.append(ex.st.pop())
@@ -1418,6 +1421,11 @@ class SEVM:
 
                 ex.next_pc()
                 stack.append((ex, step_id))
+
+            except NotImplementedError as err:
+                ex.error = f'{err}'
+                out.append(ex)
+                continue
 
             except Exception as err:
                 if self.options['debug']:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -314,43 +314,43 @@ class Exec: # an execution path
         self.balance = new_balance_var
         self.balances[new_balance_var] = new_balance
 
-    def sinit(self, slot: int, keys) -> None:
-        if slot not in self.storage[self.this]:
-            self.storage[self.this][slot] = {}
-        if len(keys) not in self.storage[self.this][slot]:
+    def sinit(self, addr: Any, slot: int, keys) -> None:
+        if slot not in self.storage[addr]:
+            self.storage[addr][slot] = {}
+        if len(keys) not in self.storage[addr][slot]:
             if len(keys) == 0:
                 if self.symbolic:
-                    self.storage[self.this][slot][len(keys)] = BitVec(f'storage_slot_{str(slot)}_{str(len(keys))}', 256)
+                    self.storage[addr][slot][len(keys)] = BitVec(f'storage_slot_{str(slot)}_{str(len(keys))}', 256)
                 else:
-                    self.storage[self.this][slot][len(keys)] = con(0)
+                    self.storage[addr][slot][len(keys)] = con(0)
             else:
                 if self.symbolic:
-                    self.storage[self.this][slot][len(keys)] = Array(f'storage_slot_{str(slot)}_{str(len(keys))}', BitVecSort(len(keys)*256), BitVecSort(256))
+                    self.storage[addr][slot][len(keys)] = Array(f'storage_slot_{str(slot)}_{str(len(keys))}', BitVecSort(len(keys)*256), BitVecSort(256))
                 else:
-                    self.storage[self.this][slot][len(keys)] = K(BitVecSort(len(keys)*256), con(0))
+                    self.storage[addr][slot][len(keys)] = K(BitVecSort(len(keys)*256), con(0))
 
-    def sload(self, loc: Word) -> Word:
+    def sload(self, addr: Any, loc: Word) -> Word:
         offsets = self.decode_storage_loc(loc)
         if not len(offsets) > 0: raise ValueError(offsets)
         slot, keys = int_of(offsets[0], 'symbolic storage base slot'), offsets[1:]
-        self.sinit(slot, keys)
+        self.sinit(addr, slot, keys)
         if len(keys) == 0:
-            return self.storage[self.this][slot][0]
+            return self.storage[addr][slot][0]
         else:
-            return self.select(self.storage[self.this][slot][len(keys)], concat(keys), self.storages)
+            return self.select(self.storage[addr][slot][len(keys)], concat(keys), self.storages)
 
-    def sstore(self, loc: Any, val: Any) -> None:
+    def sstore(self, addr: Any, loc: Any, val: Any) -> None:
         offsets = self.decode_storage_loc(loc)
         if not len(offsets) > 0: raise ValueError(offsets)
         slot, keys = int_of(offsets[0], 'symbolic storage base slot'), offsets[1:]
-        self.sinit(slot, keys)
+        self.sinit(addr, slot, keys)
         if len(keys) == 0:
-            self.storage[self.this][slot][0] = val
+            self.storage[addr][slot][0] = val
         else:
             new_storage_var = Array(f'storage{self.cnt_sstore()}', BitVecSort(len(keys)*256), BitVecSort(256))
-            new_storage = Store(self.storage[self.this][slot][len(keys)], concat(keys), val)
+            new_storage = Store(self.storage[addr][slot][len(keys)], concat(keys), val)
             self.solver.add(new_storage_var == new_storage)
-            self.storage[self.this][slot][len(keys)] = new_storage_var
+            self.storage[addr][slot][len(keys)] = new_storage_var
             self.storages[new_storage_var] = new_storage
 
     def decode_storage_loc(self, loc: Any) -> Any:
@@ -865,6 +865,17 @@ class SEVM:
                     who = simplify(Extract(511, 256, arg))
                     amount = simplify(Extract(255, 0, arg))
                     ex.balance_update(who, amount)
+                # vm.store(address,bytes32,bytes32)
+                elif eq(arg.sort(), BitVecSort((4+32*3)*8)) and simplify(Extract(799, 768, arg)) == hevm_cheat_code.store_sig:
+                    store_account = simplify(Extract(767, 512, arg))
+                    store_slot = simplify(Extract(511, 256, arg))
+                    store_value = simplify(Extract(255, 0, arg))
+                    if store_account in ex.storage:
+                        ex.sstore(store_account, store_slot, store_value)
+                    else:
+                        ex.error = f'uninitialized account: {store_account}'
+                        out.append(ex)
+                        return
                 # vm.fee(uint256)
                 elif eq(arg.sort(), BitVecSort((4+32)*8)) and simplify(Extract(287, 256, arg)) == hevm_cheat_code.fee_sig:
                     ex.block.basefee = simplify(Extract(255, 0, arg))
@@ -1340,9 +1351,9 @@ class SEVM:
                     ex.st.push(con(size))
 
                 elif opcode == EVM.SLOAD:
-                    ex.st.push(ex.sload(ex.st.pop()))
+                    ex.st.push(ex.sload(ex.this, ex.st.pop()))
                 elif opcode == EVM.SSTORE:
-                    ex.sstore(ex.st.pop(), ex.st.pop())
+                    ex.sstore(ex.this, ex.st.pop(), ex.st.pop())
 
                 elif opcode == EVM.RETURNDATASIZE:
                     ex.st.push(con(ex.returndatasize()))

--- a/tests/test/Store.t.sol
+++ b/tests/test/Store.t.sol
@@ -23,19 +23,25 @@ contract StoreTest is Test {
 //  }
 
     function testStoreScalar(uint value) public {
+        assert(uint(vm.load(address(c), 0)) == 0);
         vm.store(address(c), 0, bytes32(value));
         assert(c.x() == value);
+        assert(uint(vm.load(address(c), 0)) == value);
     }
 
     function testStoreMapping(uint key, uint value) public {
+        assert(uint(vm.load(address(c), keccak256(abi.encode(key, 1)))) == 0);
         vm.store(address(c), keccak256(abi.encode(key, 1)), bytes32(value));
         assert(c.m(key) == value);
+        assert(uint(vm.load(address(c), keccak256(abi.encode(key, 1)))) == value);
     }
 
     function testStoreArray(uint key, uint value) public {
         vm.assume(key < 2**32); // to avoid overflow
+        assert(uint(vm.load(address(c), bytes32(uint(keccak256(abi.encode(2))) + key))) == 0);
         vm.store(address(c), bytes32(uint(2)), bytes32(uint(1) + key));
         vm.store(address(c), bytes32(uint(keccak256(abi.encode(2))) + key), bytes32(value));
         assert(c.a(key) == value);
+        assert(uint(vm.load(address(c), bytes32(uint(keccak256(abi.encode(2))) + key))) == value);
     }
 }

--- a/tests/test/Store.t.sol
+++ b/tests/test/Store.t.sol
@@ -22,6 +22,12 @@ contract StoreTest is Test {
 //      assert(vm.load(address(c), key) == value);
 //  }
 
+//  TODO: support uninitialized accounts
+//  function testStoreUninit(bytes32 value) public {
+//      vm.store(address(0), 0, value);
+//      assert(vm.load(address(0), 0) == value);
+//  }
+
     function testStoreScalar(uint value) public {
         assert(uint(vm.load(address(c), 0)) == 0);
         vm.store(address(c), 0, bytes32(value));

--- a/tests/test/Store.t.sol
+++ b/tests/test/Store.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+contract C {
+    uint public x;
+    mapping (uint => uint) public m;
+    uint[] public a;
+}
+
+contract StoreTest is Test {
+    C c;
+
+    function setUp() public {
+        c = new C();
+    }
+
+//  TODO: support symbolic base slot
+//  function testStore(bytes32 key, bytes32 value) public {
+//      vm.store(address(c), key, value);
+//      assert(vm.load(address(c), key) == value);
+//  }
+
+    function testStoreScalar(uint value) public {
+        vm.store(address(c), 0, bytes32(value));
+        assert(c.x() == value);
+    }
+
+    function testStoreMapping(uint key, uint value) public {
+        vm.store(address(c), keccak256(abi.encode(key, 1)), bytes32(value));
+        assert(c.m(key) == value);
+    }
+
+    function testStoreArray(uint key, uint value) public {
+        vm.assume(key < 2**32); // to avoid overflow
+        vm.store(address(c), bytes32(uint(2)), bytes32(uint(1) + key));
+        vm.store(address(c), bytes32(uint(keccak256(abi.encode(2))) + key), bytes32(value));
+        assert(c.a(key) == value);
+    }
+}

--- a/tests/test/Store.t.sol
+++ b/tests/test/Store.t.sol
@@ -29,14 +29,12 @@ contract StoreTest is Test {
 //  }
 
     function testStoreScalar(uint value) public {
-        assert(uint(vm.load(address(c), 0)) == 0);
         vm.store(address(c), 0, bytes32(value));
         assert(c.x() == value);
         assert(uint(vm.load(address(c), 0)) == value);
     }
 
     function testStoreMapping(uint key, uint value) public {
-        assert(uint(vm.load(address(c), keccak256(abi.encode(key, 1)))) == 0);
         vm.store(address(c), keccak256(abi.encode(key, 1)), bytes32(value));
         assert(c.m(key) == value);
         assert(uint(vm.load(address(c), keccak256(abi.encode(key, 1)))) == value);
@@ -44,7 +42,6 @@ contract StoreTest is Test {
 
     function testStoreArray(uint key, uint value) public {
         vm.assume(key < 2**32); // to avoid overflow
-        assert(uint(vm.load(address(c), bytes32(uint(keccak256(abi.encode(2))) + key))) == 0);
         vm.store(address(c), bytes32(uint(2)), bytes32(uint(1) + key));
         vm.store(address(c), bytes32(uint(keccak256(abi.encode(2))) + key), bytes32(value));
         assert(c.a(key) == value);


### PR DESCRIPTION
Add initial support for vm.store() and vm.load() cheatcodes.

Current limitations:
- The base slot number must be concrete. This is the case when specific storage variables (including mappings and arrays) are accessed.
- The target address must be within the testing scope, which includes `this` and any new addresses created during the setup and current test function.