### PR TITLE
Add support for vm.etch

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -138,14 +138,6 @@ def mk_calldata(abi: List, funname: str, funsig: str, arrlen: Dict, args: argpar
 def is_stop_or_return(opcode: Byte) -> bool:
     return is_bv_value(opcode) and opcode.as_long() in [EVM.STOP, EVM.RETURN]
 
-def decode_hex(hexcode: str) -> Tuple[List[Opcode], List[Any]]:
-    if hexcode.startswith('0x'):
-        hexcode = hexcode[2:]
-    if len(hexcode) % 2 != 0: raise ValueError(hexcode)
-    (ops, code) = decode(BitVecVal(int(hexcode, 16), (len(hexcode) // 2) * 8))
-    pgm = ops_to_pgm(ops)
-    return (pgm, code)
-
 def mk_callvalue() -> Word:
     return BitVec('msg_value', 256)
 
@@ -165,15 +157,9 @@ def mk_block() -> Block:
     block.chainid = con(1) # for ethereum
     return block
 
-def mk_caller(solver) -> Word:
-    caller = BitVec('msg_sender', 256)
-    solver.add(Extract(255, 160, caller) == BitVecVal(0, 96))
-    return caller
-
-def mk_this(solver) -> Word:
-    this = BitVec('this_address', 256)
-    solver.add(Extract(255, 160, this) == BitVecVal(0, 96))
-    return this
+# TODO: addresses are used as keys in the context and could be treated as 160-bit values
+def mk_addr(name: str) -> Word:
+    return ZeroExt(96, BitVec(name, 160))
 
 def mk_solver(args: argparse.Namespace):
     solver = SolverFor('QF_AUFBV') # quantifier-free bitvector + array theory; https://smtlib.cs.uiowa.edu/logics.shtml
@@ -190,8 +176,8 @@ def run_bytecode(hexcode: str, args: argparse.Namespace, options: Dict) -> List[
     balance = mk_balance()
     block = mk_block()
     callvalue = mk_callvalue()
-    caller = mk_caller(solver)
-    this = mk_this(solver)
+    caller = mk_addr('msg_sender')
+    this = mk_addr('this_address')
 
     sevm = SEVM(options)
     ex = sevm.mk_exec(
@@ -237,7 +223,7 @@ def setup(
 
     solver = mk_solver(args)
 
-    this = mk_this(solver)
+    this = mk_addr('this_address')
 
     sevm = SEVM(options)
 
@@ -249,7 +235,7 @@ def setup(
         block     = mk_block(),
         calldata  = [],
         callvalue = con(0),
-        caller    = mk_caller(solver),
+        caller    = mk_addr('msg_sender'),
         this      = this,
         symbolic  = False,
         solver    = solver,

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -159,7 +159,7 @@ def mk_block() -> Block:
 
 # TODO: addresses are used as keys in the context and could be treated as 160-bit values
 def mk_addr(name: str) -> Word:
-    return ZeroExt(96, BitVec(name, 160))
+    return Concat(BitVecVal(0, 96), BitVec(name, 160))
 
 def mk_solver(args: argparse.Namespace):
     solver = SolverFor('QF_AUFBV') # quantifier-free bitvector + array theory; https://smtlib.cs.uiowa.edu/logics.shtml

--- a/src/halmos/byte2op.py
+++ b/src/halmos/byte2op.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0
 
-import sys
-
 from typing import List, Tuple, Any
 
 from z3 import *
@@ -40,7 +38,7 @@ def concat(args):
         return args[0]
 
 # Decode ByteCodes to Opcodes
-def decode(hexcode: BitVecVal) -> Tuple[List[Opcode], List[Any]]:
+def decode(hexcode: BitVecRef) -> Tuple[List[Opcode], List[Any]]:
     bitsize: int = hexcode.size()
     if bitsize % 8 != 0: raise ValueError(hexcode)
     code: List[Any] = [ simplify(Extract(bitsize-1 - i*8, bitsize - (i+1)*8, hexcode)) for i in range(bitsize // 8) ]

--- a/src/halmos/byte2op.py
+++ b/src/halmos/byte2op.py
@@ -21,6 +21,11 @@ class Opcode:
             ret += ' ' + str(self.op[1])
         return ret
 
+    def __repr__(self) -> str:
+        m = mnemonic(self.op[0])
+        return f'Opcode(pc={self.pc}, op={" ".join([m] + [str(x) for x in self.op[1:]])})'
+
+
 def mnemonic(opcode) -> str:
     if is_bv_value(opcode):
         opcode = opcode.as_long()
@@ -35,7 +40,7 @@ def concat(args):
         return args[0]
 
 # Decode ByteCodes to Opcodes
-def decode(hexcode: Any) -> Tuple[List[Opcode], List[Any]]:
+def decode(hexcode: BitVecVal) -> Tuple[List[Opcode], List[Any]]:
     bitsize: int = hexcode.size()
     if bitsize % 8 != 0: raise ValueError(hexcode)
     code: List[Any] = [ simplify(Extract(bitsize-1 - i*8, bitsize - (i+1)*8, hexcode)) for i in range(bitsize // 8) ]

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -106,3 +106,6 @@ class hevm_cheat_code:
 
     # bytes4(keccak256("warp(uint256)"))
     warp_sig: int = 0xe5d6bf02
+
+    # bytes4(keccak256("etch(address,bytes)"))
+    etch_sig: int = 0xb4d6c782

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -39,8 +39,8 @@ f_sdiv = Function('evm_sdiv', BitVecSort(256), BitVecSort(256), BitVecSort(256))
 f_smod = Function('evm_smod', BitVecSort(256), BitVecSort(256), BitVecSort(256))
 f_exp  = Function('evm_exp' , BitVecSort(256), BitVecSort(256), BitVecSort(256))
 
-def con(n: int) -> Word:
-    return BitVecVal(n, 256)
+def con(n: int, size_bits=256) -> Word:
+    return BitVecVal(n, size_bits)
 
 def int_of(x: Any, err: str) -> int:
     if is_bv_value(x):
@@ -951,7 +951,12 @@ class SEVM:
                 # vm.etch(address,bytes)
                 elif extract_funsig(arg) == hevm_cheat_code.etch_sig:
                     # ex.pgm contains 256-bit keys
-                    who = simplify(ZeroExt(96, extract_bytes(arg, 4 + 12, 20)))
+                    who = simplify(Concat(con(0, 96), extract_bytes(arg, 4 + 12, 20)))
+
+                    # who must be concrete
+                    if not is_bv_value(who):
+                        ex.error = f'code argument of vm.etch must be concrete but received {arg}'
+                        raise ValueError(who)
 
                     # code must be concrete
                     try:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -56,7 +56,7 @@ def wload(mem: List[Byte], loc: int, size: int) -> Bytes:
     wextend(mem, loc, size)
 
     # BitVecSort(size * 8)
-    return mem[loc] if size == 1 else simplify(Concat(mem[loc:loc+size]))
+    return simplify(concat(mem[loc:loc+size]))
 
 def wstore(mem: List[Byte], loc: int, size: int, val: Bytes) -> None:
     if not eq(val.sort(), BitVecSort(size*8)): raise ValueError(val)
@@ -987,6 +987,9 @@ class SEVM:
             stack.append((ex, step_id))
 
         # separately handle known / unknown external calls
+
+        # TODO: avoid relying directly on dict membership here
+        # it is based on hashing of the z3 expr objects rather than equivalence
         if to in ex.pgm:
             call_known()
         else:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -955,8 +955,9 @@ class SEVM:
 
                     # who must be concrete
                     if not is_bv_value(who):
-                        ex.error = f'code argument of vm.etch must be concrete but received {arg}'
-                        raise ValueError(who)
+                        ex.error = f'vm.etch(address who, bytes code) must have concrete argument `who` but received {who}'
+                        out.append(ex)
+                        return
 
                     # code must be concrete
                     try:
@@ -969,7 +970,7 @@ class SEVM:
                         ex.pgm[who] = pgm
                         ex.code[who] = code
                     except Exception as e:
-                        ex.error = f'code argument of vm.etch must be concrete but received {arg}'
+                        ex.error = f'vm.etch(address who, bytes code) must have concrete argument `code` but received calldata {arg}'
                         out.append(ex)
                         return
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -54,7 +54,9 @@ def wextend(mem: List[Byte], loc: int, size: int) -> None:
 
 def wload(mem: List[Byte], loc: int, size: int) -> Bytes:
     wextend(mem, loc, size)
-    return simplify(Concat(mem[loc:loc+size])) # BitVecSort(size * 8)
+
+    # BitVecSort(size * 8)
+    return mem[loc] if size == 1 else simplify(Concat(mem[loc:loc+size]))
 
 def wstore(mem: List[Byte], loc: int, size: int, val: Bytes) -> None:
     if not eq(val.sort(), BitVecSort(size*8)): raise ValueError(val)
@@ -74,6 +76,29 @@ def wstore_bytes(mem: List[Byte], loc: int, size: int, arr: List[Byte]) -> None:
     for i in range(size):
         if not eq(arr[i].sort(), BitVecSort(8)): raise ValueError(arr)
         mem[loc + i] = arr[i]
+
+
+def extract_bytes(data: BitVecRef, byte_offset: int, size_bytes: int) -> BitVecRef:
+    '''Extract bytes from calldata'''
+    n = data.size()
+    if n % 8 != 0: raise ValueError(n)
+
+    # will extract hi - lo + 1 bits
+    hi = n - 1 - byte_offset * 8
+    lo = n - byte_offset * 8 - size_bytes * 8
+
+    val = simplify(Extract(hi, lo, data))
+    if not eq(val.sort(), BitVecSort(size_bytes * 8)): raise ValueError(val)
+
+    return val
+
+
+def extract_funsig(calldata: BitVecRef):
+    '''Extracts the function signature (first 4 bytes) from calldata'''
+    n = calldata.size()
+    # return simplify(Extract(n-1, n-32, calldata))
+    return extract_bytes(calldata, 0, 4)
+
 
 def create_address(cnt: int) -> Word:
     return con(0x220E + cnt)
@@ -474,6 +499,22 @@ def ops_to_pgm(ops: List[Opcode]) -> List[Opcode]:
         pgm[o.pc] = o
     return pgm
 
+def decode_bytes(code_bytes: bytes) -> Tuple[List[Opcode], List[Any]]:
+    code_int = int.from_bytes(code_bytes, 'big')
+    (ops, code) = decode(BitVecVal(code_int, len(code_bytes) * 8))
+    pgm = ops_to_pgm(ops)
+    return (pgm, code)
+
+def decode_hex(hexcode: str) -> Tuple[List[Opcode], List[Any]]:
+    if len(hexcode) % 2 != 0: raise ValueError(hexcode)
+
+    if hexcode.startswith('0x'):
+        hexcode = hexcode[2:]
+
+    (ops, code) = decode(BitVecVal(int(hexcode, 16), (len(hexcode) // 2) * 8))
+    pgm = ops_to_pgm(ops)
+    return (pgm, code)
+
 #             x  == b   if sort(x) = bool
 # int_to_bool(x) == b   if sort(x) = int
 def test(x: Word, b: bool) -> Word:
@@ -685,7 +726,10 @@ class SEVM:
 
     def call(self, ex: Exec, op: int, stack: List[Tuple[Exec,int]], step_id: int, out: List[Exec]) -> None:
         gas = ex.st.pop()
+
+        # TODO: zero the upper bits
         to = ex.st.pop()
+
         if op == EVM.STATICCALL:
             fund = con(0)
         else:
@@ -824,10 +868,10 @@ class SEVM:
 
                     target = self.options['target'].rstrip('/')
                     path = target + '/' + path
-                    
+
                     with open(path) as f:
                         artifact = json.loads(f.read())
-                    
+
                     if artifact['bytecode']['object']:
                         bytecode = artifact['bytecode']['object'].replace('0x', '')
                     else:
@@ -904,6 +948,26 @@ class SEVM:
                 # vm.warp(uint256)
                 elif eq(arg.sort(), BitVecSort((4+32)*8)) and simplify(Extract(287, 256, arg)) == hevm_cheat_code.warp_sig:
                     ex.block.timestamp = simplify(Extract(255, 0, arg))
+                # vm.etch(address,bytes)
+                elif extract_funsig(arg) == hevm_cheat_code.etch_sig:
+                    # ex.pgm contains 256-bit keys
+                    who = simplify(ZeroExt(96, extract_bytes(arg, 4 + 12, 20)))
+
+                    # code must be concrete
+                    try:
+                        code_offset = extract_bytes(arg, 4 + 32, 32).as_long()
+                        code_length = extract_bytes(arg, 4 + code_offset, 32).as_long()
+                        code_int = extract_bytes(arg, 4 + code_offset + 32, code_length).as_long()
+                        code_bytes = code_int.to_bytes(code_length, 'big')
+
+                        pgm, code = decode_bytes(code_bytes)
+                        ex.pgm[who] = pgm
+                        ex.code[who] = code
+                    except Exception as e:
+                        ex.error = f'code argument of vm.etch must be concrete but received {arg}'
+                        out.append(ex)
+                        return
+
                 else:
                     # TODO: support other cheat codes
                     ex.error = str('Unsupported cheat code: calldata: ' + str(arg))

--- a/tests/test/Foundry.t.sol
+++ b/tests/test/Foundry.t.sol
@@ -51,16 +51,17 @@ contract FoundryTest is Test {
         assertEq(uint256(uint8(retval[0])), 0xAA);
     }
 
-    function testEtchSymbolicAddr(address who) public {
-        vm.etch(who, hex"60425f526001601ff3");
-        (bool success, bytes memory retval) = who.call("");
+    /// @notice etching to a symbolic address is not supported
+    // function testEtchSymbolicAddr(address who) public {
+    //     vm.etch(who, hex"60425f526001601ff3");
+    //     (bool success, bytes memory retval) = who.call("");
 
-        assertTrue(success);
-        assertEq(retval.length, 1);
-        assertEq(uint256(uint8(retval[0])), 0x42);
-    }
+    //     assertTrue(success);
+    //     assertEq(retval.length, 1);
+    //     assertEq(uint256(uint8(retval[0])), 0x42);
+    // }
 
-    /// @notice symbolic code is not supported
+    /// @notice etching symbolic code is not supported
     // function testEtchFullSymbolic(address who, bytes memory code) public {
     //     vm.etch(who, code);
     //     assertEq(code, who.code);

--- a/tests/test/Foundry.t.sol
+++ b/tests/test/Foundry.t.sol
@@ -27,4 +27,28 @@ contract FoundryTest is Test {
         counter2.set(x);
         assertEq(counter2.cnt(), x);
     }
+
+    function testEtchConcrete() public {
+        vm.etch(address(0x42), hex"60425f526001601ff3");
+        (bool success, bytes memory retval) = address(0x42).call("");
+
+        assertTrue(success);
+        assertEq(retval.length, 1);
+        assertEq(uint256(uint8(retval[0])), 0x42);
+    }
+
+    function testEtchSymbolicAddr(address who) public {
+        vm.etch(who, hex"60425f526001601ff3");
+        (bool success, bytes memory retval) = who.call("");
+
+        assertTrue(success);
+        assertEq(retval.length, 1);
+        assertEq(uint256(uint8(retval[0])), 0x42);
+    }
+
+    /// @notice symbolic code is not supported
+    // function testEtchFullSymbolic(address who, bytes memory code) public {
+    //     vm.etch(who, code);
+    //     assertEq(code, who.code);
+    // }
 }

--- a/tests/test/Foundry.t.sol
+++ b/tests/test/Foundry.t.sol
@@ -37,6 +37,20 @@ contract FoundryTest is Test {
         assertEq(uint256(uint8(retval[0])), 0x42);
     }
 
+    function testEtchOverwrite() public {
+        vm.etch(address(0x42), hex"60425f526001601ff3");
+        (, bytes memory retval) = address(0x42).call("");
+
+        assertEq(retval.length, 1);
+        assertEq(uint256(uint8(retval[0])), 0x42);
+
+        vm.etch(address(0x42), hex"60AA5f526001601ff3");
+        (, retval) = address(0x42).call("");
+
+        assertEq(retval.length, 1);
+        assertEq(uint256(uint8(retval[0])), 0xAA);
+    }
+
     function testEtchSymbolicAddr(address who) public {
         vm.etch(who, hex"60425f526001601ff3");
         (bool success, bytes memory retval) = who.call("");


### PR DESCRIPTION
Also:
- replaces mk_this and mk_caller with mk_addr(name)
- fixes an issue in wload when loading a single byte
- adds convenience method Opcode.__repr__, useful when printing
- adds convenience methods extract_bytes and extract_funsig
- adds convenience method decode_bytes, similar to decode_hex