### PR TITLE
Hide crytic-compile options by default

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -22,9 +22,22 @@ if hasattr(sys, 'set_int_max_str_digits'): # Python verion >=3.8.14, >=3.9.14, >
     sys.set_int_max_str_digits(0)
 
 def mk_crytic_parser() -> argparse.ArgumentParser:
-    crytic_compile_parser = argparse.ArgumentParser(prog='crytic-compile')
+    crytic_compile_parser = argparse.ArgumentParser()
     cryticparser.init(crytic_compile_parser)
     return crytic_compile_parser
+
+def print_help_compile(crytic_compile_parser: argparse.ArgumentParser) -> None:
+    formatter = crytic_compile_parser._get_formatter()
+    for action_group in crytic_compile_parser._action_groups:
+        if action_group.title == 'options':
+            # prints "--help", which is not helpful
+            continue
+
+        formatter.start_section(action_group.title)
+        formatter.add_text(action_group.description)
+        formatter.add_arguments(action_group._group_actions)
+        formatter.end_section()
+    crytic_compile_parser._print_message(formatter.format_help())
 
 def parse_args(args=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog='halmos', epilog='For more information, see https://github.com/a16z/halmos')
@@ -61,7 +74,7 @@ def parse_args(args=None) -> argparse.Namespace:
     parser.add_argument('--log', metavar='LOG_FILE_PATH', help='log individual execution steps in JSON')
     parser.add_argument('--print-revert', action='store_true', help='print reverting paths in verbose mode')
     parser.add_argument('--print-potential-counterexample', action='store_true', help='print potentially invalid counterexamples')
-    parser.add_argument('--compile-help', action='store_true', help='print build options (foundry, hardhat, etc.)')
+    parser.add_argument('--help-compile', action='store_true', help='print build options (foundry, hardhat, etc.)')
 
     return parser.parse_known_args(args)
 
@@ -494,8 +507,8 @@ def main() -> int:
     args, halmos_unknown_args = parse_args()
 
     crytic_compile_parser = mk_crytic_parser()
-    if args.compile_help:
-        crytic_compile_parser.print_help()
+    if args.help_compile:
+        print_help_compile(crytic_compile_parser)
         return 0
 
     options = mk_options(args)

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -21,7 +21,12 @@ from .sevm import *
 if hasattr(sys, 'set_int_max_str_digits'): # Python verion >=3.8.14, >=3.9.14, >=3.10.7, or >=3.11
     sys.set_int_max_str_digits(0)
 
-def parse_args(args) -> argparse.Namespace:
+def mk_crytic_parser() -> argparse.ArgumentParser:
+    crytic_compile_parser = argparse.ArgumentParser(prog='crytic-compile')
+    cryticparser.init(crytic_compile_parser)
+    return crytic_compile_parser
+
+def parse_args(args=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog='halmos', epilog='For more information, see https://github.com/a16z/halmos')
 
     parser.add_argument('target', metavar='TARGET_DIRECTORY', nargs='?', default=os.getcwd(), help='source root directory (default: current directory)')
@@ -56,10 +61,9 @@ def parse_args(args) -> argparse.Namespace:
     parser.add_argument('--log', metavar='LOG_FILE_PATH', help='log individual execution steps in JSON')
     parser.add_argument('--print-revert', action='store_true', help='print reverting paths in verbose mode')
     parser.add_argument('--print-potential-counterexample', action='store_true', help='print potentially invalid counterexamples')
+    parser.add_argument('--compile-help', action='store_true', help='print build options (foundry, hardhat, etc.)')
 
-    cryticparser.init(parser)
-
-    return parser.parse_args(args)
+    return parser.parse_known_args(args)
 
 def str_abi(item: Dict) -> str:
     def str_tuple(args: List) -> str:
@@ -480,14 +484,19 @@ def main() -> int:
     #
 
     set_option(max_width=240)
-    set_option(max_lines=100000000)
-#   set_option(max_depth=1000)
+    set_option(max_lines=10**8)
+    # set_option(max_depth=1000)
 
     #
     # command line arguments
     #
 
-    args = parse_args(sys.argv[1:])
+    args, halmos_unknown_args = parse_args()
+
+    crytic_compile_parser = mk_crytic_parser()
+    if args.compile_help:
+        crytic_compile_parser.print_help()
+        return 0
 
     options = mk_options(args)
 
@@ -517,7 +526,14 @@ def main() -> int:
     #
 
     try:
-        cryticCompile = CryticCompile(**vars(args))
+        crytic_compile_args, crytic_compile_unknown_args  = crytic_compile_parser.parse_known_args()
+
+        both_unknown = set(halmos_unknown_args) & set(crytic_compile_unknown_args)
+        if both_unknown:
+            print(color_warn(f'error: unrecognized arguments: {" ".join(both_unknown)}'))
+            return 1
+
+        cryticCompile = CryticCompile(target=args.target, **vars(crytic_compile_args))
     except InvalidCompilation as e:
         print(color_warn(f'Parse error: {e}'))
         return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,10 @@ from halmos.byte2op import decode, Opcode
 
 from halmos.sevm import con
 
-from halmos.__main__ import str_abi, parse_args, decode_hex, mk_options, run_bytecode
+from halmos.__main__ import str_abi, decode_hex, run_bytecode
 import halmos.__main__
+
+from test_fixtures import args, options
 
 @pytest.fixture
 def setup_abi():
@@ -38,13 +40,6 @@ def setup_sig():
 def setup_selector():
     return int('0a9254e4', 16)
 
-@pytest.fixture
-def args():
-    return parse_args([])
-
-@pytest.fixture
-def options(args):
-    return mk_options(args)
 
 def test_run_bytecode(args, options):
     hexcode = '34381856FDFDFDFDFDFD5B00'

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,18 @@
+import pytest
+
+from halmos.sevm import SEVM
+
+from halmos.__main__ import parse_args, mk_options
+
+@pytest.fixture
+def args():
+    (args, unknown_args) = parse_args([])
+    return args
+
+@pytest.fixture
+def options(args):
+    return mk_options(args)
+
+@pytest.fixture
+def sevm(options):
+    return SEVM(options)

--- a/tests/test_sevm.py
+++ b/tests/test_sevm.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 
 from z3 import *
 
@@ -7,21 +6,11 @@ from halmos.utils import EVM
 
 from halmos.byte2op import decode
 
-from halmos.sevm import SEVM, con, ops_to_pgm, f_div, f_sdiv, f_mod, f_smod, f_exp, f_origin
+from halmos.sevm import con, ops_to_pgm, f_div, f_sdiv, f_mod, f_smod, f_exp, f_origin
 
-from halmos.__main__ import parse_args, mk_options, mk_block
+from halmos.__main__ import mk_block
 
-@pytest.fixture
-def args():
-    return parse_args([])
-
-@pytest.fixture
-def options(args):
-    return mk_options(args)
-
-@pytest.fixture
-def sevm(options):
-    return SEVM(options)
+from test_fixtures import args, options, sevm
 
 caller = BitVec('msg_sender', 256)
 


### PR DESCRIPTION
Use a 2-tier argument parsing system:
- first, extract the arguments known to halmos and use that to generate the usage/help message
- second, extract the arguments known to crytic-compile
- error out if there are arguments unknown to both

Recap:
- `halmos --help` prints only the halmos options (--loop, --function, --symbolic-storage, etc.)
- `halmos --compile-help` prints the crytic-compile options (--skip-clean, --ignore-compile, etc.)
- `halmos --nonsense` prints an error message