### PR TITLE
perf: improve deepcopy

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -359,10 +359,10 @@ def run(
 
     (exs, steps) = sevm.run(Exec(
         code      = setup_ex.code.copy(), # shallow copy
-        storage   = deepcopy(setup_ex.storage),
+        storage   = deepcopy3(setup_ex.storage),
         balance   = setup_ex.balance, # TODO: add callvalue
         #
-        block     = deepcopy(setup_ex.block),
+        block     = copy.copy(setup_ex.block),
         #
         calldata  = cd,
         callvalue = callvalue,
@@ -377,14 +377,14 @@ def run(
         prank     = Prank(), # prank is reset after setUp()
         #
         solver    = solver,
-        path      = deepcopy(setup_ex.path),
+        path      = copy.copy(setup_ex.path),
         #
-        log       = deepcopy(setup_ex.log),
+        log       = copy.copy(setup_ex.log),
         cnts      = deepcopy(setup_ex.cnts),
-        sha3s     = deepcopy(setup_ex.sha3s),
-        storages  = deepcopy(setup_ex.storages),
-        balances  = deepcopy(setup_ex.balances),
-        calls     = deepcopy(setup_ex.calls),
+        sha3s     = copy.copy(setup_ex.sha3s),
+        storages  = copy.copy(setup_ex.storages),
+        balances  = copy.copy(setup_ex.balances),
+        calls     = copy.copy(setup_ex.calls),
         failed    = setup_ex.failed,
         error     = setup_ex.error,
     ))

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -217,8 +217,8 @@ class State:
 
     def __deepcopy__(self, memo): # -> State:
         st = State()
-        st.stack = deepcopy(self.stack)
-        st.memory = deepcopy(self.memory)
+        st.stack = copy.copy(self.stack)
+        st.memory = copy.copy(self.memory)
         return st
 
     def __str__(self) -> str:
@@ -412,11 +412,17 @@ class CodeIterator:
 
         return insn
 
+def deepcopy2(d: Dict[Any,Dict[Any,Any]]) -> Dict:
+    return { k : copy.copy(v) for k, v in d.items() }
+
+def deepcopy3(d: Dict[Any,Dict[Any,Dict[Any,Any]]]) -> Dict:
+    return { k : deepcopy2(v) for k, v in d.items() }
+
 
 class Exec: # an execution path
     # network
     code: Dict[Address, Contract]
-    storage: Dict[Address,Dict[int,Any]] # address -> { storage slot -> value }
+    storage: Dict[Address,Dict[int,Dict[int,Any]]] # address -> slot -> keys -> value
     balance: Any # address -> balance
     # block
     block: Block
@@ -1372,14 +1378,14 @@ class SEVM:
         new_solver.set(timeout=self.options['timeout'])
         new_solver.add(ex.solver.assertions())
         new_solver.add(cond)
-        new_path = deepcopy(ex.path)
+        new_path = copy.copy(ex.path)
         new_path.append(str(cond))
         new_ex = Exec(
             code     = ex.code.copy(), # shallow copy for potential new contract creation; existing code doesn't change
-            storage  = deepcopy(ex.storage),
-            balance  = deepcopy(ex.balance),
+            storage  = deepcopy3(ex.storage),
+            balance  = ex.balance,
             #
-            block    = deepcopy(ex.block),
+            block    = copy.copy(ex.block),
             #
             calldata = ex.calldata,
             callvalue= ex.callvalue,
@@ -1388,20 +1394,20 @@ class SEVM:
             #
             pc       = target,
             st       = deepcopy(ex.st),
-            jumpis   = deepcopy(ex.jumpis),
-            output   = deepcopy(ex.output),
+            jumpis   = deepcopy2(ex.jumpis),
+            output   = ex.output,
             symbolic = ex.symbolic,
-            prank    = deepcopy(ex.prank),
+            prank    = copy.copy(ex.prank),
             #
             solver   = new_solver,
             path     = new_path,
             #
-            log      = deepcopy(ex.log),
+            log      = copy.copy(ex.log),
             cnts     = deepcopy(ex.cnts),
-            sha3s    = deepcopy(ex.sha3s),
-            storages = deepcopy(ex.storages),
-            balances = deepcopy(ex.balances),
-            calls    = deepcopy(ex.calls),
+            sha3s    = copy.copy(ex.sha3s),
+            storages = copy.copy(ex.storages),
+            balances = copy.copy(ex.balances),
+            calls    = copy.copy(ex.calls),
             failed   = ex.failed,
             error    = ex.error,
         )


### PR DESCRIPTION
use shallow copy (or custom nested shallow copies) to ensure that z3 objects are not copied.  however, experimental results didn't show meaningful improvement. :(