### PR TITLE
feat: add halmos cheatcode support

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -568,6 +568,7 @@ def str_model(model, args: argparse.Namespace) -> str:
     def select(var):
         name = str(var)
         if name.startswith('p_'): return True
+        if name.startswith('halmos_'): return True
         elif args.verbose >= 1:
             if name.startswith('storage') or name.startswith('msg_') or name.startswith('this_'): return True
         return False

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -54,6 +54,17 @@ class Prank:
         self.keep = False
         return True
 
+class halmos_cheat_code:
+    # address constant HALMOS_ADDRESS =
+    #     address(bytes20(uint160(uint256(keccak256('halmos cheat code')))));
+    address: BitVecRef = con_addr(0x23059c36bb741986638baf337ff4d70fd1c4ef91)
+
+    # bytes4(keccak256("createSymbolicUint(uint256)"))
+    create_symbolic_uint: int = 0xfb6f0a62
+
+    # bytes4(keccak256("createSymbolicBytes(uint256)"))
+    create_symbolic_bytes: int = 0x7af8ffa5
+
 class hevm_cheat_code:
     # https://github.com/dapphub/ds-test/blob/cd98eff28324bfac652e63a239a60632a761790b/src/test.sol
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -65,6 +65,18 @@ class halmos_cheat_code:
     # bytes4(keccak256("createSymbolicBytes(uint256)"))
     create_symbolic_bytes: int = 0x7af8ffa5
 
+    # bytes4(keccak256("createSymbolicUint256()"))
+    create_symbolic_uint256: int = 0xcbf11591
+
+    # bytes4(keccak256("createSymbolicBytes32()"))
+    create_symbolic_bytes32: int = 0xea2e22e6
+
+    # bytes4(keccak256("createSymbolicAddress()"))
+    create_symbolic_address: int = 0xb6933bbe
+
+    # bytes4(keccak256("createSymbolicBool()"))
+    create_symbolic_bool: int = 0xa7e9f494
+
 class hevm_cheat_code:
     # https://github.com/dapphub/ds-test/blob/cd98eff28324bfac652e63a239a60632a761790b/src/test.sol
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1064,6 +1064,22 @@ class SEVM:
                     symbolic_bytes = BitVec(f'halmos_symbolic_bytes_{ex.new_symbol_id()}', byte_size * 8)
                     ret = Concat(BitVecVal(32, 256), BitVecVal(byte_size, 256), symbolic_bytes)
 
+                # createSymbolicUint256() returns (uint256)
+                elif funsig == halmos_cheat_code.create_symbolic_uint256:
+                    ret = BitVec(f'halmos_symbolic_uint256_{ex.new_symbol_id()}', 256)
+
+                # createSymbolicBytes32() returns (bytes32)
+                elif funsig == halmos_cheat_code.create_symbolic_bytes32:
+                    ret = BitVec(f'halmos_symbolic_bytes32_{ex.new_symbol_id()}', 256)
+
+                # createSymbolicAddress() returns (address)
+                elif funsig == halmos_cheat_code.create_symbolic_address:
+                    ret = uint256(BitVec(f'halmos_symbolic_address_{ex.new_symbol_id()}', 160))
+
+                # createSymbolicBool() returns (bool)
+                elif funsig == halmos_cheat_code.create_symbolic_bool:
+                    ret = uint256(BitVec(f'halmos_symbolic_bool_{ex.new_symbol_id()}', 1))
+
                 else:
                     ex.error = f'Unknown halmos cheat code: function selector = 0x{funsig:0>8x}, calldata = {arg}'
                     out.append(ex)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -10,7 +10,7 @@ from functools import reduce
 
 from z3 import *
 from .utils import EVM, sha3_inv, restore_precomputed_hashes, str_opcode, assert_address, con_addr
-from .cheatcodes import hevm_cheat_code, Prank
+from .cheatcodes import halmos_cheat_code, hevm_cheat_code, Prank
 
 Word = Any # z3 expression (including constants)
 Byte = Any # z3 expression (including constants)
@@ -680,6 +680,10 @@ class Exec: # an execution path
         self.cnts['fresh']['address'] += 1
         return con_addr(magic_address + new_address_offset + self.cnts['fresh']['address'])
 
+    def new_symbol_id(self) -> int:
+        self.cnts['fresh']['symbol'] += 1
+        return self.cnts['fresh']['symbol']
+
     def returndatasize(self) -> int:
         if self.output is None:
             return 0
@@ -1037,6 +1041,33 @@ class SEVM:
             # TODO: cover other precompiled
             if to == con_addr(1): # ecrecover exit code is always 1
                 ex.solver.add(exit_code_var != con(0))
+
+            # halmos cheat code
+            if to == halmos_cheat_code.address:
+                ex.solver.add(exit_code_var != con(0))
+
+                funsig: int = int_of(extract_funsig(arg), 'symbolic halmos cheatcode function selector')
+
+                # createSymbolicUint(uint256) returns (uint256)
+                if funsig == halmos_cheat_code.create_symbolic_uint:
+                    bit_size = int_of(simplify(extract_bytes(arg, 4, 32)), 'symbolic bit size for halmos.createSymbolicUint()')
+                    if bit_size <= 256:
+                        ret = uint256(BitVec(f'halmos_symbolic_uint{bit_size}_{ex.new_symbol_id()}', bit_size))
+                    else:
+                        ex.error = f'bitsize larger than 256: {bit_size}'
+                        out.append(ex)
+                        return
+
+                # createSymbolicBytes(uint256) returns (bytes)
+                elif funsig == halmos_cheat_code.create_symbolic_bytes:
+                    byte_size = int_of(simplify(extract_bytes(arg, 4, 32)), 'symbolic byte size for halmos.createSymbolicBytes()')
+                    symbolic_bytes = BitVec(f'halmos_symbolic_bytes_{ex.new_symbol_id()}', byte_size * 8)
+                    ret = Concat(BitVecVal(32, 256), BitVecVal(byte_size, 256), symbolic_bytes)
+
+                else:
+                    ex.error = f'Unknown halmos cheat code: function selector = 0x{funsig:0>8x}, calldata = {arg}'
+                    out.append(ex)
+                    return
 
             # vm cheat code
             if to == hevm_cheat_code.address:

--- a/tests/test/HalmosCheatCode.t.sol
+++ b/tests/test/HalmosCheatCode.t.sol
@@ -2,11 +2,23 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 interface Halmos {
-    // Create a new symbolic uint256 value ranging over [0, 2**bitSize - 1] (inclusive)
+    // Create a new symbolic uint value ranging over [0, 2**bitSize - 1] (inclusive)
     function createSymbolicUint(uint256 bitSize) external returns (uint256 value);
 
     // Create a new symbolic byte array with the given byte size
     function createSymbolicBytes(uint256 byteSize) external returns (bytes memory value);
+
+    // Create a new symbolic uint256 value
+    function createSymbolicUint256() external returns (uint256 value);
+
+    // Create a new symbolic bytes32 value
+    function createSymbolicBytes32() external returns (bytes32 value);
+
+    // Create a new symbolic address value
+    function createSymbolicAddress() external returns (address value);
+
+    // Create a new symbolic boolean value
+    function createSymbolicBool() external returns (bool value);
 }
 
 abstract contract HalmosTest {
@@ -21,16 +33,40 @@ contract HalmosCheatCodeTest is HalmosTest {
         uint x = halmos.createSymbolicUint(256);
         uint y = halmos.createSymbolicUint(160);
         uint z = halmos.createSymbolicUint(8);
-        assert(x <= type(uint256).max);
-        assert(y <= type(uint160).max);
-        assert(z <= type(uint8).max);
+        assert(0 <= x && x <= type(uint256).max);
+        assert(0 <= y && y <= type(uint160).max);
+        assert(0 <= z && z <= type(uint8).max);
     }
 
     function testCreateSymbolicBytes() public {
         bytes memory data = halmos.createSymbolicBytes(2);
         uint x = uint(uint8(data[0]));
         uint y = uint(uint8(data[1]));
-        assert(x <= type(uint8).max);
-        assert(y <= type(uint8).max);
+        assert(0 <= x && x <= type(uint8).max);
+        assert(0 <= y && y <= type(uint8).max);
+    }
+
+    function testCreateSymbolicUint256() public {
+        uint x = halmos.createSymbolicUint256();
+        assert(0 <= x && x <= type(uint256).max);
+    }
+
+    function testCreateSymbolicBytes32() public {
+        bytes32 x = halmos.createSymbolicBytes32();
+        assert(0 <= uint(x) && uint(x) <= type(uint256).max);
+        uint y; assembly { y := x }
+        assert(0 <= y && y <= type(uint256).max);
+    }
+
+    function testCreateSymbolicAddress() public {
+        address x = halmos.createSymbolicAddress();
+        uint y; assembly { y := x }
+        assert(0 <= y && y <= type(uint160).max);
+    }
+
+    function testCreateSymbolicBool() public {
+        bool x = halmos.createSymbolicBool();
+        uint y; assembly { y := x }
+        assert(y == 0 || y == 1);
     }
 }

--- a/tests/test/HalmosCheatCode.t.sol
+++ b/tests/test/HalmosCheatCode.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+interface Halmos {
+    // Create a new symbolic uint256 value ranging over [0, 2**bitSize - 1] (inclusive)
+    function createSymbolicUint(uint256 bitSize) external returns (uint256 value);
+
+    // Create a new symbolic byte array with the given byte size
+    function createSymbolicBytes(uint256 byteSize) external returns (bytes memory value);
+}
+
+abstract contract HalmosTest {
+    // Halmos cheat code address: 0x23059c36bb741986638baf337ff4d70fd1c4ef91
+    address internal constant HALMOS_ADDRESS = address(uint160(uint256(keccak256("halmos cheat code"))));
+
+    Halmos internal constant halmos = Halmos(HALMOS_ADDRESS);
+}
+
+contract HalmosCheatCodeTest is HalmosTest {
+    function testCreateSymbolicUint() public {
+        uint x = halmos.createSymbolicUint(256);
+        uint y = halmos.createSymbolicUint(160);
+        uint z = halmos.createSymbolicUint(8);
+        assert(x <= type(uint256).max);
+        assert(y <= type(uint160).max);
+        assert(z <= type(uint8).max);
+    }
+
+    function testCreateSymbolicBytes() public {
+        bytes memory data = halmos.createSymbolicBytes(2);
+        uint x = uint(uint8(data[0]));
+        uint y = uint(uint8(data[1]));
+        assert(x <= type(uint8).max);
+        assert(y <= type(uint8).max);
+    }
+}


### PR DESCRIPTION
add the following halmos cheatcodes for generating symbolic values:
```
    // Create a new symbolic uint value ranging over [0, 2**bitSize - 1] (inclusive)      
    function createSymbolicUint(uint256 bitSize) external returns (uint256 value);        
    
    // Create a new symbolic byte array with the given byte size                          
    function createSymbolicBytes(uint256 byteSize) external returns (bytes memory value); 
    
    // Create a new symbolic uint256 value                                                
    function createSymbolicUint256() external returns (uint256 value);                    
    
    // Create a new symbolic bytes32 value                                                
    function createSymbolicBytes32() external returns (bytes32 value);                    
    
    // Create a new symbolic address value                                                
    function createSymbolicAddress() external returns (address value);                    
    
    // Create a new symbolic boolean value                                                
    function createSymbolicBool() external returns (bool value);
```

see tests/test/HalmosCheatCode.t.sol for examples.