### PR TITLE
Support for --test-parallel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 crytic-compile >= 0.3.0
 z3-solver
+pydantic

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -9,18 +9,16 @@ import argparse
 import re
 import traceback
 
+from dataclasses import dataclass
 from multiprocessing import Pool
 from tempfile import NamedTemporaryFile
 from timeit import default_timer as timer
 
 from crytic_compile import cryticparser
 from crytic_compile import CryticCompile, InvalidCompilation
-from dataclasses import dataclass
-from multiprocessing import Pool
-from timeit import default_timer as timer
 
 from .utils import color_good, color_warn
-from .serde import save_json, load_json, fancy_type
+from .serde import save_json, load_json
 from .sevm import *
 from .warnings import *
 

--- a/src/halmos/serde.py
+++ b/src/halmos/serde.py
@@ -1,0 +1,80 @@
+import json
+
+from typing import *
+from z3 import Solver, deserialize as z3_deserialize, BitVecRef, ExprRef, SolverFor
+
+
+def save_json(exec_obj: Any, filename: str) -> None:
+    with open(filename, 'w') as f:
+        json.dump(exec_obj, f)
+
+def load_json(filename: str) -> Any:
+    with open(filename, 'r') as f:
+        return json.load(f)
+
+def serialize(item: Any) -> Any:
+    if item is None:
+        return None
+
+    # XXX: just to avoid verbose warnings
+    if isinstance(item, (str, int, bool)):
+        return item
+
+    if isinstance(item, bytes):
+        return '0x' + item.hex()
+
+    if isinstance(item, dict):
+        return { serialize(k): serialize(v) for k, v in item.items() }
+
+    if isinstance(item, list):
+        return [ serialize(x) for x in item ]
+
+    if isinstance(item, tuple):
+        return tuple(serialize(x) for x in item)
+
+    if isinstance(item, Solver):
+        return item.to_smt2()
+
+    # covers z3.BitVecRef, z3.ArrayRef, sevm.Contract, ...
+    if hasattr(item, 'serialize'):
+        return item.serialize()
+
+    if hasattr(item, '__dict__'):
+        # print(f'Warning: serializing {item} with type {type(item)} as dict')
+        return serialize(item.__dict__)
+
+    print(f'Warning: item with type {type(item)} returned as-is')
+    return item
+
+
+def fancy_type(t: Any) -> str:
+    if isinstance(t, dict):
+        for k, v in t.items():
+            return f'dict({fancy_type(k)}, {fancy_type(v)}'
+
+    if isinstance(t, list):
+        if len(t) == 0:
+            return 'list(?)'
+        else:
+            return f'list({fancy_type(t[0])})'
+
+    return str(type(t))
+
+
+Address = BitVecRef # 160-bitvector
+
+def new_solver_from_string(cls, value: str) -> Solver:
+    s = SolverFor('QF_AUFBV')
+    s.from_string(value)
+    return s
+
+def z3__pydantic__deserialize():
+    yield z3_deserialize
+
+def z3__pydantic__from_string():
+    yield new_solver_from_string
+
+# this tells pydantic to use the __get_validators function to parse/validate BitVecRef
+BitVecRef.__get_validators__ = z3__pydantic__deserialize
+ExprRef.__get_validators__ = z3__pydantic__deserialize
+Solver.__get_validators__ = z3__pydantic__from_string

--- a/tests/test/SetupPlus.t.sol
+++ b/tests/test/SetupPlus.t.sol
@@ -34,7 +34,7 @@ contract SetupPlusTest {
         a = new A(x, x);
     }
 
-    function testSetup() public {
+    function testSetupSymbolicImmutable() public {
         assert(a.x() > 10);
         assert(a.y() > 100);
     }
@@ -87,7 +87,7 @@ contract SetupPlusTestB {
         mk();
     }
 
-    function testSetup() public {
+    function testSetupSymbolicArray() public {
         assert(b.x1() == init[0]);
         assert(b.y1() == init[1]);
         assert(b.x2() == init[2]);


### PR DESCRIPTION
If there are multiple tests in the same contract, this will:

- run setUp() once,
- serialize the state (setup_ex) to disk in json
- run each test on a process pool
- the tests start by loading setup_ex from disk and run as usual (but each in their own process)

The overhead unfortunately makes `halmos --root tests` slower, but we get a nice speedup on a more realistic scenario (ERC721A):

```
halmos --solver-fresh --symbolic-storage --solver-timeout-branching 1 --skip-clean --ignore-compile --contract ERC721ATest --function test --statistics --test-parallel                                                                         

Running 19 tests for contracts/ERC721A.t.sol:ERC721ATest
[time] setup: 0.00s (decode: 0.00s, run: 0.00s)
[PASS] testMintRequirements(address,uint256) (paths: 3/7, time: 0.30s (paths: 0.29s, models: 0.00s), bounds: [])
[PASS] testMintOtherBalancePreservation(address,uint256,address) (paths: 3/10, time: 0.44s (paths: 0.44s, models: 0.00s), bounds: [])
...
[PASS] testBurnOtherOwnershipPreservation(uint256,uint256) (paths: 168/524, time: 172.07s (paths: 48.35s, models: 123.71s), bounds: [])
[PASS] testTransferOtherOwnershipPreservation(address,address,uint256,uint256) (paths: 395/1166, time: 409.30s (paths: 116.04s, models: 293.26s), bounds: [])
Symbolic test result: 19 passed; 0 failed; time: 418.55s

[time] total: 420.86s (build: 2.31s, tests: 418.55s)
```

(sequential time for me is 975.49s, so that's a 2.33x speedup 🔥)