### PR TITLE
feat: support ADDMOD, MULMOD

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -76,6 +76,7 @@ def parse_args(args=None) -> argparse.Namespace:
     group_solver.add_argument('--no-smt-sub',          action='store_true', help='do not interpret `-`')
     group_solver.add_argument('--no-smt-mul',          action='store_true', help='do not interpret `*`')
     group_solver.add_argument(   '--smt-div',          action='store_true', help=       'interpret `/`')
+    group_solver.add_argument(   '--smt-mod',          action='store_true', help=       'interpret `mod`')
     group_solver.add_argument(   '--smt-div-by-const', action='store_true', help=       'interpret division by constant')
     group_solver.add_argument(   '--smt-mod-by-const', action='store_true', help=       'interpret constant modulo')
     group_solver.add_argument(   '--smt-exp-by-const', metavar='N', type=int, default=2, help='interpret constant power up to N (default: %(default)s)')
@@ -588,6 +589,7 @@ def mk_options(args: argparse.Namespace) -> Dict:
         'sub': not args.no_smt_sub,
         'mul': not args.no_smt_mul,
         'div': args.smt_div,
+        'mod': args.smt_mod,
         'divByConst': args.smt_div_by_const,
         'modByConst': args.smt_mod_by_const,
         'expByConst': args.smt_exp_by_const,

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -467,7 +467,7 @@ def run(
             print(ex)
 
     for opcode, idx, ex in stuck:
-        print(color_warn(f'Not supported: {mnemonic(opcode)} {ex.error}'))
+        print(color_warn(f'Not supported: {mnemonic(opcode)}: {ex.error}'))
         if args.verbose >= 1:
             print(f'# {idx+1} / {len(exs)}')
             print(ex)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -934,12 +934,12 @@ class SEVM:
         w2 = b2i(w2)
         w3 = b2i(w3)
         if op == EVM.ADDMOD:
-            r1 = self.arith(ex, EVM.ADD, ZeroExt(1, w1), ZeroExt(1, w2)) # to avoid add overflow
-            r2 = self.arith(ex, EVM.MOD, r1, ZeroExt(1, w3))
+            r1 = self.arith(ex, EVM.ADD, simplify(ZeroExt(1, w1)), simplify(ZeroExt(1, w2))) # to avoid add overflow
+            r2 = self.arith(ex, EVM.MOD, simplify(r1), simplify(ZeroExt(1, w3)))
             return Extract(255, 0, r2)
         elif op == EVM.MULMOD:
-            r1 = self.arith(ex, EVM.MUL, ZeroExt(256, w1), ZeroExt(256, w2)) # to avoid mul overflow
-            r2 = self.arith(ex, EVM.MOD, r1, ZeroExt(256, w3))
+            r1 = self.arith(ex, EVM.MUL, simplify(ZeroExt(256, w1)), simplify(ZeroExt(256, w2))) # to avoid mul overflow
+            r2 = self.arith(ex, EVM.MOD, simplify(r1), simplify(ZeroExt(256, w3)))
             return Extract(255, 0, r2)
         else:
             raise ValueError(op)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1015,7 +1015,7 @@ class SEVM:
                     stack.append((new_ex, step_id))
                 else:
                     # got stuck during external call
-                    new_ex.error = f'External call stuck at: {mnemonic(opcode)}'
+                    new_ex.error = f'External call stuck at: {mnemonic(opcode)}: {new_ex.error}'
                     out.append(new_ex)
 
         def call_unknown() -> None:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1454,6 +1454,16 @@ class SEVM:
         )
         return new_ex
 
+    def sym_byte_of(self, idx: BitVecRef, w: BitVecRef) -> BitVecRef:
+        '''generate symbolic BYTE opcode result using 32 nested ite'''
+        def gen_nested_ite(curr: int) -> BitVecRef:
+            if curr < 32:
+                return If(idx == con(curr), Extract((31-curr)*8+7, (31-curr)*8, w), gen_nested_ite(curr+1))
+            else:
+                return con(0, 8)
+        # If(idx == 0, Extract(255, 248, w), If(idx == 1, Extract(247, 240, w), ..., If(idx == 31, Extract(7, 0, w), 0)...))
+        return ZeroExt(248, gen_nested_ite(0))
+
     def run(self, ex0: Exec) -> Tuple[List[Exec], Steps]:
         out: List[Exec] = []
         steps: Steps = {}
@@ -1712,13 +1722,18 @@ class SEVM:
                         ex.st.memory[loc + i] = ex.read_code(pc + i)
 
                 elif opcode == EVM.BYTE:
-                    idx: int = int_of(ex.st.pop(), 'symbolic BYTE offset')
-                    if idx < 0: raise ValueError(idx)
+                    idx = ex.st.pop()
                     w = ex.st.pop()
-                    if idx >= 32:
-                        ex.st.push(con(0))
+                    if is_bv_value(idx):
+                        idx = idx.as_long()
+                        if idx < 0: raise ValueError(idx)
+                        if idx >= 32:
+                            ex.st.push(con(0))
+                        else:
+                            ex.st.push(ZeroExt(248, Extract((31-idx)*8+7, (31-idx)*8, w)))
                     else:
-                        ex.st.push(ZeroExt(248, Extract((31-idx)*8+7, (31-idx)*8, w)))
+                        if self.options['debug']: print(f'Warning: the use of symbolic BYTE indexing may potentially impact the performance of symbolic reasoning: BYTE {idx} {w}')
+                        ex.st.push(self.sym_byte_of(idx, w))
 
                 elif EVM.LOG0 <= opcode <= EVM.LOG4:
                     num_keys: int = opcode - EVM.LOG0

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -8,6 +8,10 @@ def assert_address(x: BitVecRef) -> None:
     if x.size() != 160: raise ValueError(x)
     pass
 
+def assert_uint256(x: BitVecRef) -> None:
+    if x.size() != 256: raise ValueError(x)
+    pass
+
 def con_addr(n: int) -> BitVecRef:
     if n >= 2**160: raise ValueError(n)
     return BitVecVal(n, 160)

--- a/tests/test/Byte.t.sol
+++ b/tests/test/Byte.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+contract ByteTest {
+    function byte1(uint i, uint x) public returns (uint r) {
+        assembly { r := byte(i, x) }
+    }
+
+    function byte2(uint i, uint x) public returns (uint) {
+        if (i >= 32) return 0;
+        return (x >> (248-i*8)) & 0xff;
+    }
+
+    function byte3(uint i, uint x) public returns (uint) {
+        if (i >= 32) return 0;
+        bytes memory b = new bytes(32);
+        assembly { mstore(add(b, 32), x) }
+        return uint(uint8(bytes1(b[i]))); // TODO: Not supported: MLOAD symbolic memory offset: 160 + p_i_uint256
+    }
+
+    function testByte(uint i, uint x) public {
+        uint r1 = byte1(i, x);
+        uint r2 = byte2(i, x);
+    //  uint r3 = byte3(i, x);
+        assert(r1 == r2);
+    //  assert(r1 == r3);
+    }
+}

--- a/tests/test_sevm.py
+++ b/tests/test_sevm.py
@@ -67,6 +67,43 @@ def test_run(hexcode, stack, pc, opcode: int, sevm, solver, storage):
     assert ex.pc == pc
     assert ex.current_opcode() == int_of(opcode)
 
+def byte_of(i, x):
+    return ZeroExt(248,
+        If(i == con( 0), Extract(255, 248, x),
+        If(i == con( 1), Extract(247, 240, x),
+        If(i == con( 2), Extract(239, 232, x),
+        If(i == con( 3), Extract(231, 224, x),
+        If(i == con( 4), Extract(223, 216, x),
+        If(i == con( 5), Extract(215, 208, x),
+        If(i == con( 6), Extract(207, 200, x),
+        If(i == con( 7), Extract(199, 192, x),
+        If(i == con( 8), Extract(191, 184, x),
+        If(i == con( 9), Extract(183, 176, x),
+        If(i == con(10), Extract(175, 168, x),
+        If(i == con(11), Extract(167, 160, x),
+        If(i == con(12), Extract(159, 152, x),
+        If(i == con(13), Extract(151, 144, x),
+        If(i == con(14), Extract(143, 136, x),
+        If(i == con(15), Extract(135, 128, x),
+        If(i == con(16), Extract(127, 120, x),
+        If(i == con(17), Extract(119, 112, x),
+        If(i == con(18), Extract(111, 104, x),
+        If(i == con(19), Extract(103,  96, x),
+        If(i == con(20), Extract( 95,  88, x),
+        If(i == con(21), Extract( 87,  80, x),
+        If(i == con(22), Extract( 79,  72, x),
+        If(i == con(23), Extract( 71,  64, x),
+        If(i == con(24), Extract( 63,  56, x),
+        If(i == con(25), Extract( 55,  48, x),
+        If(i == con(26), Extract( 47,  40, x),
+        If(i == con(27), Extract( 39,  32, x),
+        If(i == con(28), Extract( 31,  24, x),
+        If(i == con(29), Extract( 23,  16, x),
+        If(i == con(30), Extract( 15,   8, x),
+        If(i == con(31), Extract(  7,   0, x),
+        BitVecVal(0, 8)))))))))))))))))))))))))))))))))
+    )
+
 @pytest.mark.parametrize('hexcode, params, output', [
     (o(EVM.PUSH0), [], con(0)),
     (o(EVM.ADD), [x, y], x + y),
@@ -123,6 +160,7 @@ def test_run(hexcode, stack, pc, opcode: int, sevm, solver, storage):
     (o(EVM.BYTE), [con(32), y], con(0)),
     (o(EVM.BYTE), [con(33), y], con(0)),
     (o(EVM.BYTE), [con(2**256-1), y], con(0)),
+    (o(EVM.BYTE), [x, y], byte_of(x, y)),
     (o(EVM.SHL), [x, y], y << x),
     (o(EVM.SHL), [con(0), y], y),
     (o(EVM.SHL), [con(255), y], y << con(255)),

--- a/tests/test_sevm.py
+++ b/tests/test_sevm.py
@@ -121,7 +121,7 @@ def byte_of(i, x):
     (o(EVM.SDIV), [con(-5), con(-3)], con(1)),
     (o(EVM.SDIV), [con(-2**255), con(-1)], con(-2**255)), # overflow
     (o(EVM.SDIV), [con(-2**255), con(-1)], con(2**255)), # overflow
-    (o(EVM.MOD), [x, y], f_mod(x,y)),
+    (o(EVM.MOD), [x, y], f_mod[x.size()](x,y)),
     (o(EVM.MOD), [con(5), con(3)], con(2)),
     (o(EVM.MOD), [x, con(0)], con(0)),
     (o(EVM.MOD), [x, con(1)], con(0)),

--- a/tests/test_sevm.py
+++ b/tests/test_sevm.py
@@ -44,6 +44,7 @@ def mk_ex(hexcode, sevm, solver, storage, caller, this):
 
 x = BitVec('x', 256)
 y = BitVec('y', 256)
+z = BitVec('z', 256)
 
 def o(opcode):
     return BitVecVal(opcode, 8)
@@ -131,8 +132,20 @@ def byte_of(i, x):
     (o(EVM.SMOD), [con(-5), con(3)], con(-2)),
     (o(EVM.SMOD), [con(5), con(-3)], con(2)),
     (o(EVM.SMOD), [con(-5), con(-3)], con(-2)),
-    # TODO: ADDMOD
-    # TODO: MULMOD
+    (o(EVM.ADDMOD), [con(4), con(1), con(3)], con(2)),
+    (o(EVM.ADDMOD), [x, y, con(0)], con(0)),
+    (o(EVM.ADDMOD), [x, y, con(1)], con(0)),
+    (o(EVM.ADDMOD), [x, y, con(2**3)], ZeroExt(253, Extract(2, 0, ZeroExt(1, x) + ZeroExt(1, y)))),
+    (o(EVM.ADDMOD), [x, y, z], Extract(255, 0, f_mod[257](ZeroExt(1, x) + ZeroExt(1, y), ZeroExt(1, z)))),
+    (o(EVM.ADDMOD), [con(10), con(10), con(8)], con(4)),
+    (o(EVM.ADDMOD), [con(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF), con(2), con(2)], con(1)),
+    (o(EVM.MULMOD), [con(5), con(1), con(3)], con(2)),
+    (o(EVM.MULMOD), [x, y, con(0)], con(0)),
+    (o(EVM.MULMOD), [x, y, con(1)], con(0)),
+    (o(EVM.MULMOD), [x, y, con(2**3)], ZeroExt(253, Extract(2, 0, ZeroExt(256, x) * ZeroExt(256, y)))),
+    (o(EVM.MULMOD), [x, y, z], Extract(255, 0, f_mod[512](ZeroExt(256, x) * ZeroExt(256, y), ZeroExt(256, z)))),
+    (o(EVM.MULMOD), [con(10), con(10), con(8)], con(4)),
+    (o(EVM.MULMOD), [con(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF), con(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF), con(12)], con(9)),
     (o(EVM.EXP), [x, y], f_exp(x,y)),
     (o(EVM.EXP), [x, con(0)], con(1)),
     (o(EVM.EXP), [x, con(1)], x),


### PR DESCRIPTION
Encoding:
- `ADDMOD(x, y, z)`: `Extract(255, 0, (ZeroExt(  1, x) + ZeroExt(  1, y)) % ZeroExt(  1, z))`
- `MULMOD(x, y, z)`: `Extract(255, 0, (ZeroExt(256, x) * ZeroExt(256, y)) % ZeroExt(256, z))`

Note that the operands are converted to a larger bitsize (257-bit for addition, and 512-bit for multiplication) to avoid overflow in the intermediate operation, and finally casted down to 256-bit.

Also, `--smt-mod` option is added to support for full mod reasoning.