### PR TITLE
Faster codecopy + create

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -306,7 +306,7 @@ def setup(
                 if res != unsat:
                     setup_exs.append(setup_ex)
 
-        if len(setup_exs) == 0: raise ValueError('No successful path found in {setup_sig}')
+        if len(setup_exs) == 0: raise ValueError(f'No successful path found in {setup_sig}')
         if len(setup_exs) > 1:
             print(color_warn(f'Warning: multiple paths were found in {setup_sig}; an arbitrary path has been selected for the following tests.'))
             if args.debug: print('\n'.join(map(str, setup_exs)))

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -299,12 +299,15 @@ def setup(
             if args.debug: print('\n'.join(setup_bounded_loops))
 
         setup_exs = []
+
         for idx, setup_ex in enumerate(setup_exs_all):
             if setup_ex.current_opcode() in [EVM.STOP, EVM.RETURN]:
                 setup_ex.solver.set(timeout=args.solver_timeout_assertion)
                 res = setup_ex.solver.check()
                 if res != unsat:
                     setup_exs.append(setup_ex)
+            elif args.debug:
+                print(color_warn(f'setup execution finished with {mnemonic(setup_ex.current_opcode())} (error={setup_ex.error})'))
 
         if len(setup_exs) == 0: raise ValueError(f'No successful path found in {setup_sig}')
         if len(setup_exs) > 1:
@@ -749,7 +752,7 @@ def main() -> int:
     if args.statistics:
         print(f'\n[time] total: {main_end - main_start:0.2f}s (build: {main_mid - main_start:0.2f}s, tests: {main_end - main_mid:0.2f}s)')
 
-    if (total_passed + total_failed) == 0:
+    if not funsigs:
         error_msg = f'Error: No tests with the prefix `{args.function}`'
         if args.contract is not None:
             error_msg += f' in {args.contract}'


### PR DESCRIPTION
Before this PR:
- everything is lowered to a bitvector byte before being stored in memory

After this PR:
- memory is now an array of either concrete or bitvector bytes
- doing a codecopy of concrete bytes keeps the bytes concrete in memory
-   (furthermore, doing a codecopy of a concrete *portion* of symbolic bytecode will also keep these bytes concrete)
- doing a create using concrete bytes in memory keeps the bytecode of the new contract concrete
- for fully symbolic bytecode or memory, the behavior is unchanged

The result is that large concrete bytecode creation is now orders of magnitude faster, which is a very common case in realistic test suites. This saves tens of thousands of Extract and Concat operation on every test!

*Caveat*: it's hard to guarantee that there aren't weird side effects (we lose the consistency of always symbolic bytes in memory), we're probably due for a separate memory refactor and mixed concrete/symbolic value wrapper.

*Perf*: 
- ERC721A before: 8 min
- ERC721A after: 3min41
