### PR TITLE
Rework parallel pool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.8.13", "3.9.13", "3.10.6"]
-        parallel: ["", "--solver-parallel --test-parallel"]
+        parallel: ["", "--test-parallel", "--solver-parallel", "--test-parallel --solver-parallel"]
         exclude:
           # python 3.8.13 is not available in windows-2022
           - os: "windows-2022"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.8.13", "3.9.13", "3.10.6"]
-        solver-parallel: ["", "--solver-parallel"]
+        parallel: ["", "--solver-parallel --test-parallel"]
         exclude:
           # python 3.8.13 is not available in windows-2022
           - os: "windows-2022"
@@ -45,4 +45,4 @@ jobs:
         run: pytest
 
       - name: Test Halmos
-        run: halmos --root tests --symbolic-storage --function test ${{ matrix.solver-parallel }}
+        run: halmos --root tests --symbolic-storage --function test ${{ matrix.parallel }}

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -588,7 +588,7 @@ def run_parallel(run_args: RunArgs) -> Tuple[int, int]:
     hexcode, abi, methodIdentifiers = run_args.hexcode, run_args.abi, run_args.methodIdentifiers
 
     setup_info = extract_setup(methodIdentifiers)
-    if args.verbose >= 1:
+    if setup_info.sig and args.verbose >= 1:
         print(f'Running {setup_info.sig}')
 
     fun_infos = [FunctionInfo(funsig.split('(')[0], funsig, methodIdentifiers[funsig]) for funsig in run_args.funsigs]
@@ -605,7 +605,7 @@ def run_parallel(run_args: RunArgs) -> Tuple[int, int]:
 
 def run_sequential(run_args: RunArgs) -> Tuple[int, int]:
     setup_info = extract_setup(run_args.methodIdentifiers)
-    if args.verbose >= 1:
+    if setup_info.sig and args.verbose >= 1:
         print(f'Running {setup_info.sig}')
 
     try:

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -595,10 +595,11 @@ def run_parallel(run_args: RunArgs) -> Tuple[int, int]:
     single_run_args = [SetupAndRunSingleArgs(hexcode, abi, setup_info, fun_info, args) for fun_info in fun_infos]
 
     # dispatch to the shared process pool
-    exitcodes = process_pool.map(setup_and_run_single, single_run_args)
+    exitcodes = list(process_pool.map(setup_and_run_single, single_run_args))
 
-    num_passed = sum(1 for x in exitcodes if x == 0)
-    num_failed = sum(1 for x in exitcodes if x != 0)
+    num_passed = exitcodes.count(0)
+    num_failed = len(exitcodes) - num_passed
+
     return num_passed, num_failed
 
 

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -98,7 +98,6 @@ def parse_args(args=None) -> argparse.Namespace:
     group_internal.add_argument('--bytecode', metavar='HEX_STRING', help='execute the given bytecode')
     group_internal.add_argument('--reset-bytecode', metavar='ADDR1=CODE1,ADDR2=CODE2,...', help='reset the bytecode of given addresses after setUp()')
     group_internal.add_argument('--test-parallel', action='store_true', help='run tests in parallel')
-    group_internal.add_argument('--max-cores', default=None, type=int, help=f'max number of cores to use for parallel processing (default: # of available cores)')
 
     # experimental options
     group_experimental = parser.add_argument_group("Experimental options")

--- a/src/halmos/pools.py
+++ b/src/halmos/pools.py
@@ -1,0 +1,5 @@
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+# defined as globals so that they can be imported from anywhere but instantiated only once
+process_pool = ProcessPoolExecutor()
+thread_pool = ThreadPoolExecutor()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,7 +108,7 @@ def test_run_bytecode(args):
 def test_setup(setup_abi, setup_name, setup_sig, setup_selector, args):
     hexcode = '600100'
     abi = setup_abi
-    setup_ex = halmos.__main__.setup(hexcode, abi, FunctionInfo(setup_name, setup_sig, setup_selector))
+    setup_ex = halmos.__main__.setup(hexcode, abi, FunctionInfo(setup_name, setup_sig, setup_selector), args)
     assert setup_ex.st.stack == [1]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from halmos.utils import EVM
 
 from halmos.sevm import con, Contract, Instruction
 
-from halmos.__main__ import str_abi, run_bytecode
+from halmos.__main__ import str_abi, run_bytecode, FunctionInfo
 import halmos.__main__
 
 from test_fixtures import args, options
@@ -95,19 +95,20 @@ RETURN""")
     assert contract.valid_jump_destinations() == set()
 
 
-def test_run_bytecode(args, options):
+def test_run_bytecode(args):
+    # sets the flag in the global args for the main module
+    args.symbolic_jump = True
+
     hexcode = '34381856FDFDFDFDFDFD5B00'
-    options['sym_jump'] = True
-    exs = run_bytecode(hexcode, args, options)
+    exs = run_bytecode(hexcode)
     assert len(exs) == 1
     assert exs[0].current_opcode() == EVM.STOP
 
 
-def test_setup(setup_abi, setup_name, setup_sig, setup_selector, args, options):
+def test_setup(setup_abi, setup_name, setup_sig, setup_selector, args):
     hexcode = '600100'
     abi = setup_abi
-    arrlen = {}
-    setup_ex = halmos.__main__.setup(hexcode, abi, setup_name, setup_sig, setup_selector, arrlen, args, options)
+    setup_ex = halmos.__main__.setup(hexcode, abi, FunctionInfo(setup_name, setup_sig, setup_selector))
     assert setup_ex.st.stack == [1]
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -3,10 +3,15 @@ import pytest
 from halmos.sevm import SEVM
 
 from halmos.__main__ import parse_args, mk_options
+import halmos.__main__
 
 @pytest.fixture
 def args():
     (args, unknown_args) = parse_args([])
+
+    # set the global args for the main module
+    halmos.__main__.args = args
+
     return args
 
 @pytest.fixture


### PR DESCRIPTION
Different take on parallel processing now that `setup()` runs faster: instead of running `setup()` once and sharing a serialized `setup_ex` with the worker process for each test, actually run `setup() + run()` for each test.

This also uses a shared ProcessPoolExecutor, since we can't have embedded multiprocessing.Pool. As a result, we should be able to combine `--solver-parallel` and `--test-parallel`

~⚠️ not ready to be merged, still experimental! (in particular the main process seems stuck at the end when we combine `--solver-parallel` and `--test-parallel`)~

*UPDATE*: with [b9d3704](https://github.com/a16z/halmos/pull/107/commits/b9d3704635610805d3abe813bc7a278b68afe41d), we can now combine `--solver-parallel` and `--test-parallel`