### PR TITLE
fix: crytic-compile version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "crytic-compile >= 0.3.0",
+    "crytic-compile >= 0.3.0, < 0.3.2",
     "z3-solver",
 ]
 dynamic = ["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-crytic-compile >= 0.3.0
+crytic-compile >= 0.3.0, < 0.3.2
 z3-solver


### PR DESCRIPTION
crytic-compile 0.3.2 introduces a breaking change to the interface.