### PR TITLE
fix: leverage better pytest output on failed tests

### DIFF
--- a/tests/test_halmos.py
+++ b/tests/test_halmos.py
@@ -77,7 +77,7 @@ def test_main(cmd, expected_path, parallel_options):
 
 
 def assert_eq(m1: Dict, m2: Dict) -> int:
-    assert m1.keys() == m2.keys()
+    assert list(m1.keys()) == list(m2.keys())
     for c in m1:
         l1 = sorted(m1[c], key=lambda x: x["name"])
         l2 = sorted(m2[c], key=lambda x: x["name"])


### PR DESCRIPTION
Comparing dict_keys gives a cryptic error message:

```
>       assert m1.keys() == m2.keys()
E       AssertionError: assert dict_keys(['t...ol:WarpTest']) == dict_keys(['t...ol:WarpTest'])
```

But with a list, it provides a helpful message:

```
>       assert list(m1.keys()) == list(m2.keys())
E       AssertionError: assert ['test/Invali...yteTest', ...] == ['test/Invali...yteTest', ...]
E         At index 1 diff: 'test/Arith.t.sol:ArithTest' != 'test/PostExample.t.sol:PostExampleTest'
E         Right contains 6 more items, first extra item: 'test/Struct.t.sol:StructTest'
E         Use -v to get more diff
```