### PR TITLE
feat: change default prefix to `check_`

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -27,7 +27,7 @@ jobs:
             branch: ""
           - repo: "farcasterxyz/contracts"
             dir: "farcaster-contracts"
-            cmd: "halmos"
+            cmd: "halmos --function check"
             branch: "test/halmos"
 
     steps:

--- a/examples/tokens/ERC20/test/DEIStablecoin.t.sol
+++ b/examples/tokens/ERC20/test/DEIStablecoin.t.sol
@@ -41,7 +41,7 @@ contract DEIStablecoinTest is ERC20Test {
         }
     }
 
-    function checkNoBackdoor(bytes4 selector, address caller, address other) public {
+    function check_NoBackdoor(bytes4 selector, address caller, address other) public {
         bytes memory args;
         if (selector == token_.acceptRecoveryAdminOwnership.selector) {
             args = abi.encode(svm.createBytes(32, 'data'));

--- a/examples/tokens/ERC20/test/ERC20Test.sol
+++ b/examples/tokens/ERC20/test/ERC20Test.sol
@@ -26,7 +26,8 @@ abstract contract ERC20Test is SymTest, Test {
 
         // consider an arbitrary function call to the token from the caller
         vm.prank(caller);
-        address(token).call(abi.encodePacked(selector, args));
+        (bool success,) = address(token).call(abi.encodePacked(selector, args));
+        vm.assume(success);
 
         uint256 newBalanceOther = IERC20(token).balanceOf(other);
 
@@ -36,7 +37,7 @@ abstract contract ERC20Test is SymTest, Test {
         }
     }
 
-    function checkTransfer(address sender, address receiver, address other, uint256 amount) public virtual {
+    function check_transfer(address sender, address receiver, address other, uint256 amount) public virtual {
         // consider other that are neither sender or receiver
         require(other != sender);
         require(other != receiver);
@@ -63,7 +64,7 @@ abstract contract ERC20Test is SymTest, Test {
         assert(IERC20(token).balanceOf(other) == oldBalanceOther);
     }
 
-    function checkTransferFrom(address caller, address from, address to, address other, uint256 amount) public virtual {
+    function check_transferFrom(address caller, address from, address to, address other, uint256 amount) public virtual {
         require(other != from);
         require(other != to);
 

--- a/examples/tokens/ERC20/test/OpenZeppelinERC20.t.sol
+++ b/examples/tokens/ERC20/test/OpenZeppelinERC20.t.sol
@@ -32,7 +32,7 @@ contract OpenZeppelinERC20Test is ERC20Test {
         }
     }
 
-    function checkNoBackdoor(bytes4 selector, address caller, address other) public {
+    function check_NoBackdoor(bytes4 selector, address caller, address other) public {
         bytes memory args = svm.createBytes(1024, 'data');
         _checkNoBackdoor(selector, args, caller, other);
     }

--- a/examples/tokens/ERC20/test/SolmateERC20.t.sol
+++ b/examples/tokens/ERC20/test/SolmateERC20.t.sol
@@ -32,7 +32,7 @@ contract SolmateERC20Test is ERC20Test {
         }
     }
 
-    function checkNoBackdoor(bytes4 selector, address caller, address other) public {
+    function check_NoBackdoor(bytes4 selector, address caller, address other) public {
         bytes memory args = svm.createBytes(1024, 'data');
         _checkNoBackdoor(selector, args, caller, other);
     }

--- a/examples/toy/test/Example.t.sol
+++ b/examples/toy/test/Example.t.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "../src/Example.sol";
 
-/// @custom:halmos --solver-fresh
+/// @custom:halmos --solver-timeout-assertion 0
 contract ExampleTest is Example {
 
     function testTotalPriceBuggy(uint96 price, uint32 quantity) public pure {

--- a/src/halmos/parser.py
+++ b/src/halmos/parser.py
@@ -157,14 +157,14 @@ def mk_arg_parser() -> argparse.ArgumentParser:
         metavar="TIMEOUT",
         type=int,
         default=1,
-        help="set timeout (in milliseconds) for solving branching conditions (default: %(default)s)",
+        help="set timeout (in milliseconds) for solving branching conditions; 0 means no timeout (default: %(default)s)",
     )
     group_solver.add_argument(
         "--solver-timeout-assertion",
         metavar="TIMEOUT",
         type=int,
         default=1000,
-        help="set timeout (in milliseconds) for solving assertion violation conditions (default: %(default)s)",
+        help="set timeout (in milliseconds) for solving assertion violation conditions; 0 means no timeout (default: %(default)s)",
     )
     group_solver.add_argument(
         "--solver-fresh",

--- a/src/halmos/parser.py
+++ b/src/halmos/parser.py
@@ -23,7 +23,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--function",
         metavar="FUNCTION_NAME_PREFIX",
-        default="check",
+        default="check_",
         help="run tests matching the given prefix only (default: %(default)s)",
     )
 

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -3,7 +3,7 @@
     "test_results": {
         "test/Invalid.t.sol:OldCompilerTest": [
             {
-                "name": "checkAssert(uint256)",
+                "name": "check_assert(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -11,7 +11,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkMyAssert(uint256)",
+                "name": "check_myAssert(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -21,7 +21,7 @@
         ],
         "test/Arith.t.sol:ArithTest": [
             {
-                "name": "checkExp(uint256)",
+                "name": "check_Exp(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -29,7 +29,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkMod(uint256,uint256,address)",
+                "name": "check_Mod(uint256,uint256,address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -39,7 +39,7 @@
         ],
         "test/AssertTest.sol:CTest": [
             {
-                "name": "checkBar()",
+                "name": "check_bar()",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -47,7 +47,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkFoo()",
+                "name": "check_foo()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -57,7 +57,7 @@
         ],
         "test/Block.t.sol:BlockCheatCodeTest": [
             {
-                "name": "checkChainId(uint64)",
+                "name": "check_chainId(uint64)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -65,7 +65,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkCoinbase(address)",
+                "name": "check_coinbase(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -73,7 +73,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkDifficulty(uint256)",
+                "name": "check_difficulty(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -81,7 +81,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkFee(uint256)",
+                "name": "check_fee(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -89,7 +89,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkRoll(uint256)",
+                "name": "check_roll(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -97,7 +97,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarp(uint256)",
+                "name": "check_warp(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -107,7 +107,7 @@
         ],
         "test/Byte.t.sol:ByteTest": [
             {
-                "name": "checkByte(uint256,uint256)",
+                "name": "check_byte(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -117,7 +117,7 @@
         ],
         "test/Byte.t.sol:SymbolicByteTest": [
             {
-                "name": "checkSymbolicByteIndex(uint8,uint8)",
+                "name": "check_SymbolicByteIndex(uint8,uint8)",
                 "exitcode": 1,
                 "num_models": 2,
                 "num_paths": null,
@@ -127,7 +127,7 @@
         ],
         "test/Console.t.sol:ConsoleTest": [
             {
-                "name": "checkLog()",
+                "name": "check_log()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -137,7 +137,7 @@
         ],
         "test/Const.t.sol:ConstTest": [
             {
-                "name": "checkConst()",
+                "name": "check_Const()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -147,7 +147,7 @@
         ],
         "test/Const.t.sol:ConstTestTest": [
             {
-                "name": "checkConst()",
+                "name": "check_Const()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -157,7 +157,7 @@
         ],
         "test/Counter.t.sol:CounterTest": [
             {
-                "name": "checkDiv1(uint256,uint256)",
+                "name": "check_div_1(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -165,7 +165,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkDiv2(uint256,uint256)",
+                "name": "check_div_2(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -173,7 +173,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkFoo(uint256,uint256,uint256,uint256)",
+                "name": "check_foo(uint256,uint256,uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -181,7 +181,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkInc()",
+                "name": "check_inc()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -189,7 +189,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkIncBy(uint256)",
+                "name": "check_incBy(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -197,7 +197,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkIncOpt()",
+                "name": "check_incOpt()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -205,7 +205,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoopConst()",
+                "name": "check_loopConst()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -213,7 +213,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoopConstIf()",
+                "name": "check_loopConstIf()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -221,7 +221,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoopDoWhile(uint8)",
+                "name": "check_loopDoWhile(uint8)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -229,7 +229,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoopFor(uint8)",
+                "name": "check_loopFor(uint8)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -237,7 +237,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoopWhile(uint8)",
+                "name": "check_loopWhile(uint8)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -245,7 +245,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkMulDiv(uint256,uint256)",
+                "name": "check_mulDiv(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -253,7 +253,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSet(uint256)",
+                "name": "check_set(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -261,7 +261,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSetString(uint256,string,uint256,string,uint256)",
+                "name": "check_setString(uint256,string,uint256,string,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -269,7 +269,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSetSum(uint248,uint248)",
+                "name": "check_setSum(uint248,uint248)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -279,7 +279,7 @@
         ],
         "test/Create.t.sol:CreateTest": [
             {
-                "name": "checkConst()",
+                "name": "check_const()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -287,7 +287,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkImmutable()",
+                "name": "check_immutable()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -295,7 +295,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkInitialized()",
+                "name": "check_initialized()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -303,7 +303,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSet(uint256)",
+                "name": "check_set(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -313,7 +313,7 @@
         ],
         "test/Deal.t.sol:DealTest": [
             {
-                "name": "checkDeal1(address,uint256)",
+                "name": "check_deal_1(address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -321,7 +321,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkDeal2(address,uint256,uint256)",
+                "name": "check_deal_2(address,uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -329,7 +329,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkDealNew()",
+                "name": "check_deal_new()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -339,7 +339,7 @@
         ],
         "test/Foundry.t.sol:FoundryTest": [
             {
-                "name": "checkAssume(uint256)",
+                "name": "check_assume(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -347,7 +347,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkEtchConcrete()",
+                "name": "check_deployCode(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -355,7 +355,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkEtchOverwrite()",
+                "name": "check_etch_Concrete()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -363,7 +363,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkGetCode(uint256)",
+                "name": "check_etch_Overwrite()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -373,7 +373,7 @@
         ],
         "test/Getter.t.sol:GetterTest": [
             {
-                "name": "checkGetter(uint256)",
+                "name": "check_Getter(uint256)",
                 "exitcode": 1,
                 "num_models": 0,
                 "num_paths": null,
@@ -383,7 +383,7 @@
         ],
         "test/HalmosCheatCode.t.sol:HalmosCheatCodeTest": [
             {
-                "name": "checkFailUnknownCheatcode()",
+                "name": "check_FailUnknownCheatcode()",
                 "exitcode": 1,
                 "num_models": 0,
                 "num_paths": null,
@@ -391,7 +391,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolLabel()",
+                "name": "check_SymbolLabel()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -399,7 +399,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolicAddress()",
+                "name": "check_createAddress()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -407,7 +407,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolicBool()",
+                "name": "check_createBool()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -415,7 +415,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolicBytes()",
+                "name": "check_createBytes()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -423,7 +423,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolicBytes32()",
+                "name": "check_createBytes32()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -431,7 +431,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolicUint()",
+                "name": "check_createUint()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -439,7 +439,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSymbolicUint256()",
+                "name": "check_createUint256()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -449,7 +449,7 @@
         ],
         "test/Library.t.sol:LibraryTest": [
             {
-                "name": "checkAdd(uint256,uint256)",
+                "name": "check_add(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -460,7 +460,7 @@
         "test/LibraryLinking.t.sol:LibTest": [],
         "test/LibraryLinking.t.sol:LibTest2": [
             {
-                "name": "checkBar()",
+                "name": "check_bar()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -470,7 +470,7 @@
         ],
         "test/List.t.sol:ListTest": [
             {
-                "name": "checkAdd(uint256)",
+                "name": "check_add(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -478,7 +478,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkRemove()",
+                "name": "check_remove()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -486,7 +486,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSet(uint256,uint256)",
+                "name": "check_set(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -496,7 +496,7 @@
         ],
         "test/List.t.sol:ListTestTest": [
             {
-                "name": "checkAdd(uint256)",
+                "name": "check_add(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -504,7 +504,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkRemove()",
+                "name": "check_remove()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -512,7 +512,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSet(uint256,uint256)",
+                "name": "check_set(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -522,7 +522,7 @@
         ],
         "test/Math.t.sol:MathTest": [
             {
-                "name": "checkAvg(uint256,uint256)",
+                "name": "check_Avg(uint256,uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -532,7 +532,7 @@
         ],
         "test/Natspec.t.sol:NatspecTestContract": [
             {
-                "name": "checkLoop3(uint256)",
+                "name": "check_Loop3(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -540,7 +540,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop3Fail(uint256)",
+                "name": "check_Loop3Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -550,7 +550,7 @@
         ],
         "test/Natspec.t.sol:NatspecTestFunction": [
             {
-                "name": "checkLoop2(uint256)",
+                "name": "check_Loop2(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -558,7 +558,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop2Fail(uint256)",
+                "name": "check_Loop2Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -566,7 +566,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop3(uint256)",
+                "name": "check_Loop3(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -574,7 +574,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop3Fail(uint256)",
+                "name": "check_Loop3Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -584,7 +584,7 @@
         ],
         "test/Natspec.t.sol:NatspecTestNone": [
             {
-                "name": "checkLoop2(uint256)",
+                "name": "check_Loop2(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -592,7 +592,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop2Fail(uint256)",
+                "name": "check_Loop2Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -602,7 +602,7 @@
         ],
         "test/Natspec.t.sol:NatspecTestOverwrite": [
             {
-                "name": "checkLoop3(uint256)",
+                "name": "check_Loop3(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -610,7 +610,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop3Fail(uint256)",
+                "name": "check_Loop3Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -618,7 +618,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop4(uint256)",
+                "name": "check_Loop4(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -626,7 +626,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop4Fail(uint256)",
+                "name": "check_Loop4Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -636,7 +636,7 @@
         ],
         "test/Natspec.t.sol:NatspecTestSetup": [
             {
-                "name": "checkLoop2(uint256)",
+                "name": "check_Loop2(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -644,7 +644,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkLoop2Fail(uint256)",
+                "name": "check_Loop2Fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -654,7 +654,7 @@
         ],
         "test/Opcode.t.sol:OpcodeTest": [
             {
-                "name": "checkPush0()",
+                "name": "check_PUSH0()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -672,7 +672,7 @@
         ],
         "test/Prank.t.sol:PrankSetUpTest": [
             {
-                "name": "checkPrank(address)",
+                "name": "check_prank(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -682,7 +682,7 @@
         ],
         "test/Prank.t.sol:PrankTest": [
             {
-                "name": "checkPrank(address)",
+                "name": "check_prank(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -690,7 +690,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkPrankExternal(address)",
+                "name": "check_prank_External(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -698,7 +698,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkPrankExternalSelf(address)",
+                "name": "check_prank_ExternalSelf(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -706,7 +706,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkPrankInternal(address)",
+                "name": "check_prank_Internal(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -714,7 +714,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkPrankNew(address)",
+                "name": "check_prank_New(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -722,7 +722,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkPrankReset1(address)",
+                "name": "check_prank_Reset1(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -730,7 +730,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkPrankReset2(address)",
+                "name": "check_prank_Reset2(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -738,7 +738,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkStartPrank(address)",
+                "name": "check_startPrank(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -746,7 +746,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkStopPrank1(address)",
+                "name": "check_stopPrank_1(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -754,7 +754,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkStopPrank2()",
+                "name": "check_stopPrank_2()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -764,7 +764,7 @@
         ],
         "test/Proxy.t.sol:ProxyTest": [
             {
-                "name": "checkFoo(uint256)",
+                "name": "check_foo(uint256)",
                 "exitcode": 1,
                 "num_models": 0,
                 "num_paths": null,
@@ -774,7 +774,7 @@
         ],
         "test/Reset.t.sol:ResetTest": [
             {
-                "name": "checkFoo()",
+                "name": "check_foo()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -784,7 +784,7 @@
         ],
         "test/Revert.t.sol:CTest": [
             {
-                "name": "checkRevert1(uint256)",
+                "name": "check_Revert1(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -792,7 +792,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkRevert2(uint256)",
+                "name": "check_Revert2(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -802,7 +802,7 @@
         ],
         "test/Send.t.sol:SendTest": [
             {
-                "name": "checkSend(address,uint256,address)",
+                "name": "check_Send(address,uint256,address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -810,7 +810,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSendSelf(address,uint256,address)",
+                "name": "check_SendSelf(address,uint256,address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -820,7 +820,7 @@
         ],
         "test/Setup.t.sol:SetupTest": [
             {
-                "name": "checkTrue()",
+                "name": "check_True()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -830,7 +830,7 @@
         ],
         "test/SetupPlus.t.sol:SetupPlusTest": [
             {
-                "name": "checkSetup()",
+                "name": "check_Setup()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -840,7 +840,7 @@
         ],
         "test/SetupPlus.t.sol:SetupPlusTestB": [
             {
-                "name": "checkSetup()",
+                "name": "check_Setup()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -850,7 +850,7 @@
         ],
         "test/SetupSymbolic.t.sol:SetupSymbolicTest": [
             {
-                "name": "checkFoo()",
+                "name": "check_True()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -860,7 +860,7 @@
         ],
         "test/SignExtend.t.sol:SignExtendTest": [
             {
-                "name": "checkSignExtend(int16)",
+                "name": "check_SIGNEXTEND(int16)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -870,7 +870,7 @@
         ],
         "test/Solver.t.sol:SolverTest": [
             {
-                "name": "checkFoo(uint256,uint256)",
+                "name": "check_foo(uint256,uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -880,7 +880,7 @@
         ],
         "test/Storage.t.sol:StorageTest": [
             {
-                "name": "checkAddArr1(uint256)",
+                "name": "check_addArr1(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -888,7 +888,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkAddArr2(uint256,uint256)",
+                "name": "check_addArr2(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -896,7 +896,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkAddMap1Arr1(uint256,uint256)",
+                "name": "check_addMap1Arr1(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -904,7 +904,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSetMap1(uint256,uint256)",
+                "name": "check_setMap1(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -912,7 +912,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSetMap2(uint256,uint256,uint256)",
+                "name": "check_setMap2(uint256,uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -920,7 +920,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkSetMap3(uint256,uint256,uint256,uint256)",
+                "name": "check_setMap3(uint256,uint256,uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -930,7 +930,7 @@
         ],
         "test/Store.t.sol:StoreTest": [
             {
-                "name": "checkStoreArray(uint256,uint256)",
+                "name": "check_store_Array(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -938,7 +938,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkStoreMapping(uint256,uint256)",
+                "name": "check_store_Mapping(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -946,7 +946,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkStoreScalar(uint256)",
+                "name": "check_store_Scalar(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -956,7 +956,7 @@
         ],
         "test/Struct.t.sol:StructTest": [
             {
-                "name": "checkStruct((uint256,uint256))",
+                "name": "check_Struct((uint256,uint256))",
                 "exitcode": 2,
                 "num_models": null,
                 "num_paths": null,
@@ -966,7 +966,7 @@
         ],
         "test/TestConstructor.t.sol:TestConstructorTest": [
             {
-                "name": "checkValue()",
+                "name": "check_value()",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -976,7 +976,7 @@
         ],
         "test/Token.t.sol:TokenTest": [
             {
-                "name": "checkBalanceInvariant()",
+                "name": "check_BalanceInvariant()",
                 "exitcode": 1,
                 "num_models": 2,
                 "num_paths": null,
@@ -986,7 +986,7 @@
         ],
         "test/UnsupportedOpcode.t.sol:X": [
             {
-                "name": "checkFoo()",
+                "name": "check_foo()",
                 "exitcode": 1,
                 "num_models": 0,
                 "num_paths": null,
@@ -996,7 +996,7 @@
         ],
         "test/UnsupportedOpcode.t.sol:Y": [
             {
-                "name": "checkFoo()",
+                "name": "check_foo()",
                 "exitcode": 1,
                 "num_models": 0,
                 "num_paths": null,
@@ -1006,7 +1006,7 @@
         ],
         "test/UnsupportedOpcode.t.sol:Z": [
             {
-                "name": "checkFoo()",
+                "name": "check_foo()",
                 "exitcode": 1,
                 "num_models": 0,
                 "num_paths": null,
@@ -1016,7 +1016,7 @@
         ],
         "test/Warp.t.sol:WarpTest": [
             {
-                "name": "checkWarp(uint256)",
+                "name": "check_warp(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -1024,7 +1024,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarpExternal(uint256)",
+                "name": "check_warp_External(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -1032,7 +1032,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarpExternalSelf(uint256)",
+                "name": "check_warp_ExternalSelf(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -1040,7 +1040,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarpInternal(uint256)",
+                "name": "check_warp_Internal(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -1048,7 +1048,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarpNew(uint256)",
+                "name": "check_warp_New(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -1056,7 +1056,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarpReset(uint256,uint256)",
+                "name": "check_warp_Reset(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -1064,7 +1064,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkWarpSetUp()",
+                "name": "check_warp_SetUp()",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,

--- a/tests/expected/erc20.json
+++ b/tests/expected/erc20.json
@@ -3,7 +3,7 @@
     "test_results": {
         "test/DEIStablecoin.t.sol:DEIStablecoinTest": [
             {
-                "name": "checkNoBackdoor(bytes4,address,address)",
+                "name": "check_NoBackdoor(bytes4,address,address)",
                 "exitcode": 1,
                 "num_models": 1,
                 "num_paths": null,
@@ -11,7 +11,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransfer(address,address,address,uint256)",
+                "name": "check_transfer(address,address,address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -19,7 +19,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransferFrom(address,address,address,address,uint256)",
+                "name": "check_transferFrom(address,address,address,address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -29,7 +29,7 @@
         ],
         "test/OpenZeppelinERC20.t.sol:OpenZeppelinERC20Test": [
             {
-                "name": "checkNoBackdoor(bytes4,address,address)",
+                "name": "check_NoBackdoor(bytes4,address,address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -37,7 +37,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransfer(address,address,address,uint256)",
+                "name": "check_transfer(address,address,address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -45,7 +45,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransferFrom(address,address,address,address,uint256)",
+                "name": "check_transferFrom(address,address,address,address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -55,7 +55,7 @@
         ],
         "test/SolmateERC20.t.sol:SolmateERC20Test": [
             {
-                "name": "checkNoBackdoor(bytes4,address,address)",
+                "name": "check_NoBackdoor(bytes4,address,address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -63,7 +63,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransfer(address,address,address,uint256)",
+                "name": "check_transfer(address,address,address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -71,7 +71,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransferFrom(address,address,address,address,uint256)",
+                "name": "check_transferFrom(address,address,address,address,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,

--- a/tests/expected/erc721.json
+++ b/tests/expected/erc721.json
@@ -3,7 +3,7 @@
     "test_results": {
         "test/OpenZeppelinERC721.t.sol:OpenZeppelinERC721Test": [
             {
-                "name": "checkNoBackdoor(bytes4)",
+                "name": "check_NoBackdoor(bytes4)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -11,7 +11,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransferFrom(address,address,address,address,uint256,uint256)",
+                "name": "check_transferFrom(address,address,address,address,uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -21,7 +21,7 @@
         ],
         "test/SolmateERC721.t.sol:SolmateERC721Test": [
             {
-                "name": "checkNoBackdoor(bytes4)",
+                "name": "check_NoBackdoor(bytes4)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,
@@ -29,7 +29,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "checkTransferFrom(address,address,address,address,uint256,uint256)",
+                "name": "check_transferFrom(address,address,address,address,uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "num_paths": null,

--- a/tests/test/Arith.t.sol
+++ b/tests/test/Arith.t.sol
@@ -9,7 +9,7 @@ contract ArithTest {
         }
     }
 
-    function checkMod(uint x, uint y, address addr) public pure {
+    function check_Mod(uint x, uint y, address addr) public pure {
         unchecked {
             assert(unchecked_mod(x, 0) == 0); // compiler rejects `x % 0`
             assert(x % 1 == 0);
@@ -24,7 +24,7 @@ contract ArithTest {
         }
     }
 
-    function checkExp(uint x) public pure {
+    function check_Exp(uint x) public pure {
         unchecked {
             assert(x ** 0 == 1); // 0 ** 0 == 1
             assert(x ** 1 == x);

--- a/tests/test/AssertTest.sol
+++ b/tests/test/AssertTest.sol
@@ -20,11 +20,11 @@ contract CTest is Test {
         c = new C();
     }
 
-    function checkFoo() public {
+    function check_foo() public {
         address(c).call(abi.encodeWithSelector(C.foo.selector, bytes(""))); // pass
     }
 
-    function checkBar() public {
+    function check_bar() public {
         address(c).call(abi.encodeWithSelector(C.bar.selector, bytes(""))); // fail
     }
 }

--- a/tests/test/Block.t.sol
+++ b/tests/test/Block.t.sol
@@ -4,32 +4,32 @@ pragma solidity >=0.8.0 <0.9.0;
 import "forge-std/Test.sol";
 
 contract BlockCheatCodeTest is Test {
-    function checkFee(uint x) public {
+    function check_fee(uint x) public {
         vm.fee(x);
         assert(block.basefee == x);
     }
 
-    function checkChainId(uint64 x) public {
+    function check_chainId(uint64 x) public {
         vm.chainId(x);
         assert(block.chainid == x);
     }
 
-    function checkCoinbase(address x) public {
+    function check_coinbase(address x) public {
         vm.coinbase(x);
         assert(block.coinbase == x);
     }
 
-    function checkDifficulty(uint x) public {
+    function check_difficulty(uint x) public {
         vm.difficulty(x);
         assert(block.difficulty == x);
     }
 
-    function checkRoll(uint x) public {
+    function check_roll(uint x) public {
         vm.roll(x);
         assert(block.number == x);
     }
 
-    function checkWarp(uint x) public {
+    function check_warp(uint x) public {
         vm.warp(x);
         assert(block.timestamp == x);
     }

--- a/tests/test/Byte.t.sol
+++ b/tests/test/Byte.t.sol
@@ -18,7 +18,7 @@ contract ByteTest {
         return uint(uint8(bytes1(b[i]))); // TODO: Not supported: MLOAD symbolic memory offset: 160 + p_i_uint256
     }
 
-    function checkByte(uint i, uint x) pure public {
+    function check_byte(uint i, uint x) pure public {
         uint r1 = byte1(i, x);
         uint r2 = byte2(i, x);
     //  uint r3 = byte3(i, x); // not supported
@@ -28,7 +28,7 @@ contract ByteTest {
 }
 
 contract SymbolicByteTest {
-    function checkSymbolicByteIndex(uint8 x, uint8 i) public pure returns (uint r) {
+    function check_SymbolicByteIndex(uint8 x, uint8 i) public pure returns (uint r) {
         if (x > 10) assert(false); // expected to fail
         assembly {
             r := byte(i, x)

--- a/tests/test/Console.t.sol
+++ b/tests/test/Console.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import "forge-std/Test.sol";
 
 contract ConsoleTest is Test {
-    function checkLog() public view {
+    function check_log() public view {
         console.log(0);
         console.log(1);
     }

--- a/tests/test/Const.t.sol
+++ b/tests/test/Const.t.sol
@@ -5,13 +5,13 @@ import "forge-std/Test.sol";
 import "../src/Const.sol";
 
 contract ConstTest is Const {
-    function checkConst() public pure {
+    function check_Const() public pure {
         assert(const == 11);
     }
 }
 
 contract ConstTestTest is Const, Test {
-    function checkConst() public {
+    function check_Const() public {
         assertEq(const, 11);
     }
 }

--- a/tests/test/Counter.t.sol
+++ b/tests/test/Counter.t.sol
@@ -5,19 +5,19 @@ import "../src/Counter.sol";
 
 /// @custom:halmos --loop 4 --symbolic-storage
 contract CounterTest is Counter {
-    function checkSet(uint n) public {
+    function check_set(uint n) public {
         set(n);
         assert(cnt == n);
     }
 
-    function checkInc() public {
+    function check_inc() public {
         uint oldCnt = cnt;
         inc();
         assert(cnt > oldCnt);
         assert(cnt == oldCnt + 1);
     }
 
-    function checkIncOpt() public {
+    function check_incOpt() public {
         uint oldCnt = cnt;
         require(cnt < type(uint).max);
         incOpt();
@@ -25,7 +25,7 @@ contract CounterTest is Counter {
         assert(cnt == oldCnt + 1);
     }
 
-    function checkIncBy(uint n) public {
+    function check_incBy(uint n) public {
         uint oldCnt = cnt;
         incBy(n);
         assert(cnt < oldCnt || cnt == oldCnt + n); // cnt >= oldCnt ==> cnt == oldCnt + n
@@ -37,7 +37,7 @@ contract CounterTest is Counter {
         assert(cnt >= oldCnt);
         assert(cnt == oldCnt + n);
     }
-    function checkLoopFor(uint8 k) public {
+    function check_loopFor(uint8 k) public {
         specLoopFor(k);
     }
 
@@ -47,7 +47,7 @@ contract CounterTest is Counter {
         assert(cnt >= oldCnt);
         assert(cnt == oldCnt + n);
     }
-    function checkLoopWhile(uint8 k) public {
+    function check_loopWhile(uint8 k) public {
         specLoopWhile(k);
     }
 
@@ -58,18 +58,18 @@ contract CounterTest is Counter {
         if (n == 0) assert(cnt == oldCnt + 1);
         else assert(cnt == oldCnt + n);
     }
-    function checkLoopDoWhile(uint8 k) public {
+    function check_loopDoWhile(uint8 k) public {
         specLoopDoWhile(k);
     }
 
-    function checkLoopConst() public {
+    function check_loopConst() public {
         uint oldCnt = cnt;
         loopConst();
         assert(cnt >= oldCnt);
         assert(cnt == oldCnt + 2);
     }
 
-    function checkLoopConstIf() public {
+    function check_loopConstIf() public {
         uint oldCnt = cnt;
         loopConstIf();
         assert(cnt >= oldCnt);
@@ -80,36 +80,36 @@ contract CounterTest is Counter {
         setSum(arr);
         assert(cnt == arr[0] + arr[1]);
     }
-    function checkSetSum(uint248 a, uint248 b) public {
+    function check_setSum(uint248 a, uint248 b) public {
         specSetSum([uint(a), b]);
     }
 
-    function checkSetString(uint, string memory s, uint, string memory r, uint) public {
+    function check_setString(uint, string memory s, uint, string memory r, uint) public {
         uint oldCnt = cnt;
         setString(s);
         setString(r);
         assert(cnt == oldCnt + bytes(s).length + bytes(r).length);
     }
 
-    function checkFoo(uint a, uint b, uint c, uint d) public {
+    function check_foo(uint a, uint b, uint c, uint d) public {
         uint oldCnt = cnt;
         foo(a, b, c, d);
         assert(cnt == oldCnt + 4);
     }
 
-    function checkDiv1(uint x, uint y) public pure {
+    function check_div_1(uint x, uint y) public pure {
         if (y > 0) {
             assert(x / y <= x);
         }
     }
 
-    function checkDiv2(uint x, uint y) public pure {
+    function check_div_2(uint x, uint y) public pure {
         if (y > 0) {
             assert(x / y == x / y);
         }
     }
 
-    function checkMulDiv(uint x, uint y) public pure {
+    function check_mulDiv(uint x, uint y) public pure {
         unchecked {
             if (x > 0 && y > 0) {
                 uint z = x * y;

--- a/tests/test/Create.t.sol
+++ b/tests/test/Create.t.sol
@@ -12,25 +12,25 @@ contract CreateTest is Test {
     }
 
     /* TODO: support checkFail prefix
-    function checkFailSetUp() public {
+    function checkFail_setUp() public {
         assertEq(create.value(), 0);
     }
     */
 
-    function checkSet(uint x) public {
+    function check_set(uint x) public {
         create.set(x);
         assertEq(create.value(), x);
     }
 
-    function checkImmutable() public {
+    function check_immutable() public {
         assertEq(create.halmos(), 0x220E);
     }
 
-    function checkInitialized() public {
+    function check_initialized() public {
         assertEq(create.initialized(), 7);
     }
 
-    function checkConst() public {
+    function check_const() public {
         assertEq(create.const(), 11);
     }
 }

--- a/tests/test/Deal.t.sol
+++ b/tests/test/Deal.t.sol
@@ -6,18 +6,18 @@ import "forge-std/Test.sol";
 contract DealTest is Test {
     C c;
 
-    function checkDeal1(address payable receiver, uint amount) public {
+    function check_deal_1(address payable receiver, uint amount) public {
         vm.deal(receiver, amount);
         assert(receiver.balance == amount);
     }
 
-    function checkDeal2(address payable receiver, uint amount1, uint amount2) public {
+    function check_deal_2(address payable receiver, uint amount1, uint amount2) public {
         vm.deal(receiver, amount1);
         vm.deal(receiver, amount2); // reset the balance, not increasing
         assert(receiver.balance == amount2);
     }
 
-    function checkDealNew() public {
+    function check_deal_new() public {
         vm.deal(address(this), 3 ether);
 
         c = new C{value: 3 ether}();

--- a/tests/test/Foundry.t.sol
+++ b/tests/test/Foundry.t.sol
@@ -13,12 +13,12 @@ contract FoundryTest is Test {
     }
     */
 
-    function checkAssume(uint x) public {
+    function check_assume(uint x) public {
         vm.assume(x < 10);
         assertLt(x, 100);
     }
 
-    function checkGetCode(uint x) public {
+    function check_deployCode(uint x) public {
         Counter counter = Counter(deployCode("./out/Counter.sol/Counter.json"));
         counter.set(x);
         assertEq(counter.cnt(), x);
@@ -28,7 +28,7 @@ contract FoundryTest is Test {
         assertEq(counter2.cnt(), x);
     }
 
-    function checkEtchConcrete() public {
+    function check_etch_Concrete() public {
         vm.etch(address(0x42), hex"60425f526001601ff3");
         (bool success, bytes memory retval) = address(0x42).call("");
 
@@ -37,7 +37,7 @@ contract FoundryTest is Test {
         assertEq(uint256(uint8(retval[0])), 0x42);
     }
 
-    function checkEtchOverwrite() public {
+    function check_etch_Overwrite() public {
         vm.etch(address(0x42), hex"60425f526001601ff3");
         (, bytes memory retval) = address(0x42).call("");
 
@@ -52,7 +52,7 @@ contract FoundryTest is Test {
     }
 
     /// @notice etching to a symbolic address is not supported
-    // function checkEtchSymbolicAddr(address who) public {
+    // function check_etch_SymbolicAddr(address who) public {
     //     vm.etch(who, hex"60425f526001601ff3");
     //     (bool success, bytes memory retval) = who.call("");
 
@@ -62,7 +62,7 @@ contract FoundryTest is Test {
     // }
 
     /// @notice etching symbolic code is not supported
-    // function checkEtchFullSymbolic(address who, bytes memory code) public {
+    // function check_etch_FullSymbolic(address who, bytes memory code) public {
     //     vm.etch(who, code);
     //     assertEq(code, who.code);
     // }

--- a/tests/test/Getter.t.sol
+++ b/tests/test/Getter.t.sol
@@ -7,7 +7,7 @@ contract GetterTest {
     uint256[3] v;
     uint w;
 
-    function checkGetter(uint256 i) public view {
+    function check_Getter(uint256 i) public view {
         assert(v[i] >= 0); // unsupported static storage arrays
     }
 }

--- a/tests/test/HalmosCheatCode.t.sol
+++ b/tests/test/HalmosCheatCode.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 
 contract HalmosCheatCodeTest is SymTest {
-    function checkSymbolicUint() public {
+    function check_createUint() public {
         uint x = svm.createUint(256, 'x');
         uint y = svm.createUint(160, 'y');
         uint z = svm.createUint(8, 'z');
@@ -13,7 +13,7 @@ contract HalmosCheatCodeTest is SymTest {
         assert(0 <= z && z <= type(uint8).max);
     }
 
-    function checkSymbolicBytes() public {
+    function check_createBytes() public {
         bytes memory data = svm.createBytes(2, 'data');
         uint x = uint(uint8(data[0]));
         uint y = uint(uint8(data[1]));
@@ -21,31 +21,31 @@ contract HalmosCheatCodeTest is SymTest {
         assert(0 <= y && y <= type(uint8).max);
     }
 
-    function checkSymbolicUint256() public {
+    function check_createUint256() public {
         uint x = svm.createUint256('x');
         assert(0 <= x && x <= type(uint256).max);
     }
 
-    function checkSymbolicBytes32() public {
+    function check_createBytes32() public {
         bytes32 x = svm.createBytes32('x');
         assert(0 <= uint(x) && uint(x) <= type(uint256).max);
         uint y; assembly { y := x }
         assert(0 <= y && y <= type(uint256).max);
     }
 
-    function checkSymbolicAddress() public {
+    function check_createAddress() public {
         address x = svm.createAddress('x');
         uint y; assembly { y := x }
         assert(0 <= y && y <= type(uint160).max);
     }
 
-    function checkSymbolicBool() public {
+    function check_createBool() public {
         bool x = svm.createBool('x');
         uint y; assembly { y := x }
         assert(y == 0 || y == 1);
     }
 
-    function checkSymbolLabel() public returns (uint256) {
+    function check_SymbolLabel() public returns (uint256) {
         uint x = svm.createUint256('');
         uint y = svm.createUint256(' ');
         uint z = svm.createUint256(' a ');
@@ -53,7 +53,7 @@ contract HalmosCheatCodeTest is SymTest {
         return x + y + z + w;
     }
 
-    function checkFailUnknownCheatcode() public {
+    function check_FailUnknownCheatcode() public {
         Dummy(address(svm)).foo(); // expected to fail with unknown cheatcode
     }
 }

--- a/tests/test/Invalid.t.sol
+++ b/tests/test/Invalid.t.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.5.2;
 
 contract OldCompilerTest {
 
-    function checkAssert(uint x) public pure {
+    function check_assert(uint x) public pure {
         if (x == 0) return;
         assert(false); // old compiler versions don't revert with panic; instead, they run invalid opcode, which halmos ignores, resulting in no error here.
     }
 
-    function checkMyAssert(uint x) public pure {
+    function check_myAssert(uint x) public pure {
         if (x == 0) return;
         myAssert(false); // you can use your own assertion that panic-reverts if assertion fails, when using halmos for old version code.
     }

--- a/tests/test/Library.t.sol
+++ b/tests/test/Library.t.sol
@@ -14,7 +14,7 @@ library Math {
 }
 
 contract LibraryTest {
-    function checkAdd(uint x, uint y) public pure {
+    function check_add(uint x, uint y) public pure {
         unchecked {
             assert(Math._add(x,y) == x+y);
             /* TODO: support public library functions (library linking)

--- a/tests/test/LibraryLinking.t.sol
+++ b/tests/test/LibraryLinking.t.sol
@@ -7,13 +7,13 @@ library Lib {
 }
 
 contract LibTest {
-    function checkFoo() public pure {
+    function check_foo() public pure {
         assert(Lib.foo() == 1); // library linking placeholder error
     }
 }
 
 contract LibTest2 {
-    function checkBar() public pure {
+    function check_bar() public pure {
         assert(Lib.bar() == 2); // this is fine because internal library functions are inlined
     }
 }

--- a/tests/test/List.t.sol
+++ b/tests/test/List.t.sol
@@ -6,7 +6,7 @@ import "../src/List.sol";
 
 /// @custom:halmos --symbolic-storage
 contract ListTest is Test, List {
-    function checkAdd(uint x) public {
+    function check_add(uint x) public {
         uint oldSize = arr.length;
         vm.assume(oldSize < type(uint).max);
         add(x);
@@ -16,7 +16,7 @@ contract ListTest is Test, List {
         assert(arr[newSize-1] == x);
     }
 
-    function checkRemove() public {
+    function check_remove() public {
         uint oldSize = arr.length;
         vm.assume(oldSize > 0);
         remove();
@@ -25,7 +25,7 @@ contract ListTest is Test, List {
         assert(oldSize == newSize + 1);
     }
 
-    function checkSet(uint i, uint x) public {
+    function check_set(uint i, uint x) public {
         vm.assume(i < arr.length);
         set(i, x);
         assert(arr[i] == x);
@@ -41,7 +41,7 @@ contract ListTestTest is Test {
         list.add(1);
     }
 
-    function checkAdd(uint x) public {
+    function check_add(uint x) public {
         uint oldSize = list.size();
         vm.assume(oldSize < type(uint).max);
         list.add(x);
@@ -51,7 +51,7 @@ contract ListTestTest is Test {
         assert(list.arr(newSize-1) == x);
     }
 
-    function checkRemove() public {
+    function check_remove() public {
         uint oldSize = list.size();
         vm.assume(oldSize > 0);
         list.remove();
@@ -60,7 +60,7 @@ contract ListTestTest is Test {
         assert(oldSize == newSize + 1);
     }
 
-    function checkSet(uint i, uint x) public {
+    function check_set(uint i, uint x) public {
         vm.assume(i < list.size());
         list.set(i, x);
         assert(list.arr(i) == x);

--- a/tests/test/Math.t.sol
+++ b/tests/test/Math.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 contract MathTest {
-    function checkAvg(uint a, uint b) public pure {
+    function check_Avg(uint a, uint b) public pure {
         unchecked {
             uint r1 = (a & b) + (a ^ b) / 2;
             uint r2 = (a + b) / 2;

--- a/tests/test/Natspec.t.sol
+++ b/tests/test/Natspec.t.sol
@@ -8,10 +8,10 @@ contract NatspecTestNone {
         l = new Loop();
     }
 
-    function checkLoop2(uint n) public view {
+    function check_Loop2(uint n) public view {
         assert(l.iter(n) <= 2); // pass // default
     }
-    function checkLoop2Fail(uint n) public view {
+    function check_Loop2Fail(uint n) public view {
         assert(l.iter(n) <= 1); // fail // default
     }
 }
@@ -24,10 +24,10 @@ contract NatspecTestContract {
         l = new Loop();
     }
 
-    function checkLoop3(uint n) public view {
+    function check_Loop3(uint n) public view {
         assert(l.iter(n) <= 3); // pass // inherited from contract
     }
-    function checkLoop3Fail(uint n) public view {
+    function check_Loop3Fail(uint n) public view {
         assert(l.iter(n) <= 2); // fail // inherited from contract
     }
 }
@@ -40,10 +40,10 @@ contract NatspecTestSetup {
         l = new Loop();
     }
 
-    function checkLoop2(uint n) public view {
+    function check_Loop2(uint n) public view {
         assert(l.iter(n) <= 2); // pass // default
     }
-    function checkLoop2Fail(uint n) public view {
+    function check_Loop2Fail(uint n) public view {
         assert(l.iter(n) <= 1); // fail // default
     }
 }
@@ -56,18 +56,18 @@ contract NatspecTestFunction {
     }
 
     /// @custom:halmos --loop 3
-    function checkLoop3(uint n) public view {
+    function check_Loop3(uint n) public view {
         assert(l.iter(n) <= 3); // pass
     }
     /// @custom:halmos --loop 3
-    function checkLoop3Fail(uint n) public view {
+    function check_Loop3Fail(uint n) public view {
         assert(l.iter(n) <= 2); // fail
     }
 
-    function checkLoop2(uint n) public view {
+    function check_Loop2(uint n) public view {
         assert(l.iter(n) <= 2); // pass // default
     }
-    function checkLoop2Fail(uint n) public view {
+    function check_Loop2Fail(uint n) public view {
         assert(l.iter(n) <= 1); // fail // default
     }
 }
@@ -80,19 +80,19 @@ contract NatspecTestOverwrite {
         l = new Loop();
     }
 
-    function checkLoop4(uint n) public view {
+    function check_Loop4(uint n) public view {
         assert(l.iter(n) <= 4); // pass // inherited from contract
     }
-    function checkLoop4Fail(uint n) public view {
+    function check_Loop4Fail(uint n) public view {
         assert(l.iter(n) <= 3); // fail // inherited from contract
     }
 
     /// @custom:halmos --loop 3
-    function checkLoop3(uint n) public view {
+    function check_Loop3(uint n) public view {
         assert(l.iter(n) <= 3); // pass // overwrite
     }
     /// @custom:halmos --loop 3
-    function checkLoop3Fail(uint n) public view {
+    function check_Loop3Fail(uint n) public view {
         assert(l.iter(n) <= 2); // fail // overwrite
     }
 }

--- a/tests/test/Opcode.t.sol
+++ b/tests/test/Opcode.t.sol
@@ -46,7 +46,7 @@ contract OpcodeTest is Test {
         assertEq(result1, result2);
     }
 
-    function checkPush0() public {
+    function check_PUSH0() public {
         // target bytecode is 0x365f5f37365ff3
         //  36 CALLDATASIZE
         //  5F PUSH0

--- a/tests/test/Prank.t.sol
+++ b/tests/test/Prank.t.sol
@@ -140,14 +140,14 @@ contract PrankTest is Test {
         assert(target.caller() == address(this));
     }
 
-    function checkPrankConstructor(address user) public {
+    function check_prank_Constructor(address user) public {
         vm.prank(user);
         ConstructorRecorder recorder = new ConstructorRecorder();
         assert(recorder.caller() == user);
     }
 
     // TODO: uncomment when we add CREATE2 support
-    // function checkPrankConstructorCreate2(address user, bytes32 salt) public {
+    // function check_prank_ConstructorCreate2(address user, bytes32 salt) public {
     //     vm.prank(user);
     //     ConstructorRecorder recorder = new ConstructorRecorder{salt:salt}();
     //     assert(recorder.caller() == user);

--- a/tests/test/Prank.t.sol
+++ b/tests/test/Prank.t.sol
@@ -31,7 +31,7 @@ contract PrankSetUpTest is Test {
         vm.prank(address(target)); // prank is reset after setUp()
     }
 
-    function checkPrank(address user) public {
+    function check_prank(address user) public {
         vm.prank(user);
         target.recordCaller();
         assert(target.caller() == user);
@@ -52,7 +52,7 @@ contract PrankTest is Test {
         vm.prank(user);
     }
 
-    function checkPrank(address user) public {
+    function check_prank(address user) public {
         vm.prank(user);
         target.recordCaller();
         assert(target.caller() == user);
@@ -61,7 +61,7 @@ contract PrankTest is Test {
         assert(target.caller() == address(this));
     }
 
-    function checkStartPrank(address user) public {
+    function check_startPrank(address user) public {
         vm.startPrank(user);
 
         target.recordCaller();
@@ -79,25 +79,25 @@ contract PrankTest is Test {
         assert(target.caller() == address(this));
     }
 
-    function checkPrankInternal(address user) public {
+    function check_prank_Internal(address user) public {
         prank(user); // indirect prank
         target.recordCaller();
         assert(target.caller() == user);
     }
 
-    function checkPrankExternal(address user) public {
+    function check_prank_External(address user) public {
         ext.prank(user); // prank isn't propagated beyond the vm boundry
         target.recordCaller();
         assert(target.caller() == address(this));
     }
 
-    function checkPrankExternalSelf(address user) public {
+    function check_prank_ExternalSelf(address user) public {
         this.prank(user); // prank isn't propagated beyond the vm boundry
         target.recordCaller();
         assert(target.caller() == address(this));
     }
 
-    function checkPrankNew(address user) public {
+    function check_prank_New(address user) public {
         vm.prank(user);
         dummy = new Dummy(); // contract creation also consumes prank
         vm.prank(user);
@@ -105,28 +105,28 @@ contract PrankTest is Test {
         assert(target.caller() == user);
     }
 
-    function checkPrankReset1(address user) public {
+    function check_prank_Reset1(address user) public {
     //  vm.prank(address(target)); // overwriting active prank is not allowed
         vm.prank(user);
         target.recordCaller();
         assert(target.caller() == user);
     }
 
-    function checkPrankReset2(address user) public {
+    function check_prank_Reset2(address user) public {
     //  vm.prank(address(target)); // overwriting active prank is not allowed
         vm.startPrank(user);
         target.recordCaller();
         assert(target.caller() == user);
     }
 
-    function checkStopPrank1(address user) public {
+    function check_stopPrank_1(address user) public {
         vm.prank(user);
         vm.stopPrank(); // stopPrank can be used to disable both startPrank() and prank()
         target.recordCaller();
         assert(target.caller() == address(this));
     }
 
-    function checkStopPrank2() public {
+    function check_stopPrank_2() public {
         vm.stopPrank(); // stopPrank is allowed even when no active prank exists!
         target.recordCaller();
         assert(target.caller() == address(this));

--- a/tests/test/Proxy.t.sol
+++ b/tests/test/Proxy.t.sol
@@ -20,7 +20,7 @@ contract ProxyTest is Test {
         c = C(address(new ERC1967Proxy(address(cImpl), "")));
     }
 
-    function checkFoo(uint x) public {
+    function check_foo(uint x) public {
         c.foo(x);
         assert(c.num() == x); // currently unsupported // TODO: support DELEGATECALL
         assert(cImpl.num() == 0);

--- a/tests/test/Reset.t.sol
+++ b/tests/test/Reset.t.sol
@@ -15,7 +15,7 @@ contract ResetTest {
         c = new C();
     }
 
-    function checkFoo() public view {
+    function check_foo() public view {
         assert(c.foo() == 2); // for testing --reset-bytecode option
     }
 

--- a/tests/test/Revert.t.sol
+++ b/tests/test/Revert.t.sol
@@ -24,14 +24,14 @@ contract CTest {
         c = new C();
     }
 
-    function checkRevert1(uint256 x) public {
+    function check_Revert1(uint256 x) public {
         require(x != 0);
         (bool result, ) = address(c).call(abi.encodeWithSignature("set1(uint256)", x));
         assert(!result);
         assert(c.num() != x); // fail // TODO: fix reverting semantics
     }
 
-    function checkRevert2(uint256 x) public {
+    function check_Revert2(uint256 x) public {
         require(x != 0);
         (bool result, ) = address(c).call(abi.encodeWithSignature("set2(uint256)", x));
         assert(!result);

--- a/tests/test/Send.t.sol
+++ b/tests/test/Send.t.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 
 contract SendTest {
 
-    function checkSend(address payable receiver, uint amount, address others) public {
+    function check_Send(address payable receiver, uint amount, address others) public {
         require(others != address(this) && others != receiver);
 
         require(address(this) != receiver);
@@ -26,7 +26,7 @@ contract SendTest {
         }
     }
 
-    function checkSendSelf(address payable receiver, uint amount, address others) public {
+    function check_SendSelf(address payable receiver, uint amount, address others) public {
         require(others != address(this) && others != receiver);
 
         require(address(this) == receiver);

--- a/tests/test/Setup.t.sol
+++ b/tests/test/Setup.t.sol
@@ -15,7 +15,7 @@ contract SetupTest is Test {
         }
     }
 
-    function checkTrue() public {
+    function check_True() public {
         assertEq(users[0], address(bytes20(keccak256("test"))));
         assertEq(users[1], address(uint160(users[0]) + 1));
         assertEq(users[2], address(0));

--- a/tests/test/SetupPlus.t.sol
+++ b/tests/test/SetupPlus.t.sol
@@ -34,7 +34,7 @@ contract SetupPlusTest {
         a = new A(x, x);
     }
 
-    function checkSetup() public view {
+    function check_Setup() public view {
         assert(a.x() > 10);
         assert(a.y() > 100);
     }
@@ -87,7 +87,7 @@ contract SetupPlusTestB {
         mk();
     }
 
-    function checkSetup() public view {
+    function check_Setup() public view {
         assert(b.x1() == init[0]);
         assert(b.y1() == init[1]);
         assert(b.x2() == init[2]);

--- a/tests/test/SetupSymbolic.t.sol
+++ b/tests/test/SetupSymbolic.t.sol
@@ -6,7 +6,7 @@ contract SetupSymbolicTest {
         if (x > 0) return; // generate multiple setup output states
     }
 
-    function checkFoo() public pure {
+    function check_True() public pure {
         assert(true); // ensure setUp succeeds
     }
 }

--- a/tests/test/SignExtend.t.sol
+++ b/tests/test/SignExtend.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import "../src/SignExtend.sol";
 
 contract SignExtendTest is SignExtend {
-    function checkSignExtend(int16 _x) public pure {
+    function check_SIGNEXTEND(int16 _x) public pure {
         int16 x = changeMySign(_x);
         assert(x == -_x);
     }

--- a/tests/test/Solver.t.sol
+++ b/tests/test/Solver.t.sol
@@ -12,7 +12,7 @@ contract SolverTest {
         else return x;
     }
 
-    function checkFoo(uint a, uint b) public pure {
+    function check_foo(uint a, uint b) public pure {
         if(b > a) {
             assert(foo(b) > foo(a));
         }

--- a/tests/test/Storage.t.sol
+++ b/tests/test/Storage.t.sol
@@ -6,36 +6,36 @@ import "../src/Storage.sol";
 
 /// @custom:halmos --symbolic-storage
 contract StorageTest is Storage {
-    function checkSetMap1(uint k, uint v) public {
+    function check_setMap1(uint k, uint v) public {
         setMap1(k, v);
         assert(map1[k] == v);
     }
 
-    function checkSetMap2(uint k1, uint k2, uint v) public {
+    function check_setMap2(uint k1, uint k2, uint v) public {
         setMap2(k1, k2, v);
         assert(map2[k1][k2] == v);
     }
 
-    function checkSetMap3(uint k1, uint k2, uint k3, uint v) public {
+    function check_setMap3(uint k1, uint k2, uint k3, uint v) public {
         setMap3(k1, k2, k3, v);
         assert(map3[k1][k2][k3] == v);
     }
 
-    function checkAddArr1(uint v) public {
+    function check_addArr1(uint v) public {
         uint size = arr1.length;
         addArr1(v);
         assert(arr1.length == size + 1);
         assert(arr1[size] == v);
     }
 
-    function checkAddArr2(uint i, uint v) public {
+    function check_addArr2(uint i, uint v) public {
         uint size = arr2[i].length;
         addArr2(i, v);
         assert(arr2[i].length == size + 1);
         assert(arr2[i][size] == v);
     }
 
-    function checkAddMap1Arr1(uint k, uint v) public {
+    function check_addMap1Arr1(uint k, uint v) public {
         uint size = map1Arr1[k].length;
         addMap1Arr1(k, v);
         assert(map1Arr1[k].length == size + 1);

--- a/tests/test/Store.t.sol
+++ b/tests/test/Store.t.sol
@@ -17,30 +17,30 @@ contract StoreTest is Test {
     }
 
 //  TODO: support symbolic base slot
-//  function checkStore(bytes32 key, bytes32 value) public {
+//  function check_store(bytes32 key, bytes32 value) public {
 //      vm.store(address(c), key, value);
 //      assert(vm.load(address(c), key) == value);
 //  }
 
 //  TODO: support uninitialized accounts
-//  function checkStoreUninit(bytes32 value) public {
+//  function check_store_Uninit(bytes32 value) public {
 //      vm.store(address(0), 0, value);
 //      assert(vm.load(address(0), 0) == value);
 //  }
 
-    function checkStoreScalar(uint value) public {
+    function check_store_Scalar(uint value) public {
         vm.store(address(c), 0, bytes32(value));
         assert(c.x() == value);
         assert(uint(vm.load(address(c), 0)) == value);
     }
 
-    function checkStoreMapping(uint key, uint value) public {
+    function check_store_Mapping(uint key, uint value) public {
         vm.store(address(c), keccak256(abi.encode(key, 1)), bytes32(value));
         assert(c.m(key) == value);
         assert(uint(vm.load(address(c), keccak256(abi.encode(key, 1)))) == value);
     }
 
-    function checkStoreArray(uint key, uint value) public {
+    function check_store_Array(uint key, uint value) public {
         vm.assume(key < 2**32); // to avoid overflow
         vm.store(address(c), bytes32(uint(2)), bytes32(uint(1) + key));
         vm.store(address(c), bytes32(uint(keccak256(abi.encode(2))) + key), bytes32(value));

--- a/tests/test/Struct.t.sol
+++ b/tests/test/Struct.t.sol
@@ -8,7 +8,7 @@ contract StructTest {
     }
 
     // TODO: support struct parameter
-    function checkStruct(Point memory) public pure {
+    function check_Struct(Point memory) public pure {
         assert(true);
     }
 }

--- a/tests/test/TestConstructor.t.sol
+++ b/tests/test/TestConstructor.t.sol
@@ -5,7 +5,7 @@ contract TestConstructorTest {
 
     uint public value = 1;
 
-    function checkValue() public view {
+    function check_value() public view {
         assert(value == 1); // fail // TODO: consider test contract constructor
     }
 

--- a/tests/test/Token.t.sol
+++ b/tests/test/Token.t.sol
@@ -19,7 +19,7 @@ contract TokenTest is SymTest, Test {
         }
     }
 
-    function checkBalanceInvariant() public {
+    function check_BalanceInvariant() public {
         // consider two arbitrary distinct accounts
         address caller = svm.createAddress('caller');
         address others = svm.createAddress('others');

--- a/tests/test/UnsupportedOpcode.t.sol
+++ b/tests/test/UnsupportedOpcode.t.sol
@@ -8,7 +8,7 @@ contract X {
         }
     }
 
-    function checkFoo() public {
+    function check_foo() public {
         foo(); // unsupported error
     }
 }
@@ -20,7 +20,7 @@ contract Y {
         x = new X();
     }
 
-    function checkFoo() public {
+    function check_foo() public {
         x.foo(); // unsupported error
     }
 }
@@ -33,7 +33,7 @@ contract Z {
         y.setUp();
     }
 
-    function checkFoo() public {
-        y.checkFoo(); // unsupported error
+    function check_foo() public {
+        y.check_foo(); // unsupported error
     }
 }

--- a/tests/test/Warp.t.sol
+++ b/tests/test/Warp.t.sol
@@ -28,39 +28,39 @@ contract WarpTest is Test {
         vm.warp(time);
     }
 
-    function checkWarp(uint time) public {
+    function check_warp(uint time) public {
         vm.warp(time);
         assert(block.timestamp == time);
     }
 
-    function checkWarpInternal(uint time) public {
+    function check_warp_Internal(uint time) public {
         warp(time);
         assert(block.timestamp == time);
     }
 
-    function checkWarpExternal(uint time) public {
+    function check_warp_External(uint time) public {
         ext.warp(time);
         assert(block.timestamp == time);
     }
 
-    function checkWarpExternalSelf(uint time) public {
+    function check_warp_ExternalSelf(uint time) public {
         this.warp(time);
         assert(block.timestamp == time);
     }
 
-    function checkWarpNew(uint time) public {
+    function check_warp_New(uint time) public {
         c = new C(time);
         assert(block.timestamp == time);
     }
 
-    function checkWarpReset(uint time1, uint time2) public {
+    function check_warp_Reset(uint time1, uint time2) public {
         vm.warp(time1);
         assert(block.timestamp == time1);
         vm.warp(time2);
         assert(block.timestamp == time2);
     }
 
-    function checkWarpSetUp() public view {
+    function check_warp_SetUp() public view {
         assert(block.timestamp == 1000);
     }
 }


### PR DESCRIPTION
Rationale: The current default prefix `check` often conflicts with other non-testing functions such as `checkpoint` or `checkSignature`. The new default prefix `check_` doesn't conflict with non-testing functions that follow the CamelCase naming convention. Also, using underscores for naming testing functions is considered a [best practice](https://book.getfoundry.sh/tutorials/best-practices#tests).