### PR TITLE
add explicit message when we find a library placeholder

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -22,7 +22,7 @@ from .utils import (
     hexify,
 )
 from .cheatcodes import halmos_cheat_code, hevm_cheat_code, console, Prank
-from .warnings import warn, UNSUPPORTED_OPCODE
+from .warnings import warn, UNSUPPORTED_OPCODE, LIBRARY_PLACEHOLDER
 
 Word = Any  # z3 expression (including constants)
 Byte = Any  # z3 expression (including constants)
@@ -501,7 +501,13 @@ class Contract:
         if hexcode.startswith("0x"):
             hexcode = hexcode[2:]
 
-        return Contract(bytes.fromhex(hexcode))
+        if "__" in hexcode:
+            warn(LIBRARY_PLACEHOLDER, f"contract hexcode contains library placeholder")
+
+        try:
+            return Contract(bytes.fromhex(hexcode))
+        except ValueError as e:
+            raise ValueError(f"{e} (hexcode={hexcode})")
 
     def decode_instruction(self, pc: int) -> Instruction:
         opcode = int_of(self[pc])

--- a/src/halmos/warnings.py
+++ b/src/halmos/warnings.py
@@ -22,6 +22,7 @@ COUNTEREXAMPLE_INVALID = ErrorCode("counterexample-invalid")
 COUNTEREXAMPLE_UNKNOWN = ErrorCode("counterexample-unknown")
 INTERNAL_ERROR = ErrorCode("internal-error")
 UNSUPPORTED_OPCODE = ErrorCode("unsupported-opcode")
+LIBRARY_PLACEHOLDER = ErrorCode("library-placeholder")
 
 LOOP_BOUND = ErrorCode("loop-bound")
 


### PR DESCRIPTION
Before:

    Error: None failed: ValueError: non-hexadecimal number found in fromhex() arg at position 104

After:

    WARNING:Halmos:contract hexcode contains library placeholder
    (see https://github.com/a16z/halmos/wiki/warnings#library-placeholder)
    Error: None failed: ValueError: non-hexadecimal number found in fromhex() arg at position 104 (hexcode=6080604052348015600e575f80fd5b50600436106026575f3560e01c8063e6d8ab5714602a575b5f80fd5b60306032565b005b73__$72fd9f18565b1bf49af679aa1eb458ccdd$__63c29855786040518163ffffffff1660e01b8152600401602060405180830381865af41580156078573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190609a919060a8565b60011460a65760a660be565b565b5f6020828403121560b7575f80fd5b5051919050565b634e487b7160e01b5f52600160045260245ffdfea2646970667358221220718127b2b6ab931470aa18feed33867fe44f4298c582940b611bde59dc4d049664736f6c63430008140033)