### PR TITLE
fix: resolving address alias for infeasible paths

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1524,17 +1524,13 @@ class SEVM:
 
         if target not in ex.alias:
             for addr in ex.code:
-                if (
-                    # must equal
-                    ex.check(target != addr) == unsat
-                    # ensure existing path condition is feasible
-                    and ex.check(target == addr) != unsat
-                ):
+                if ex.check(target != addr) == unsat:  # target == addr
                     if self.options.get("debug"):
                         print(
                             f"[DEBUG] Address alias: {hexify(addr)} for {hexify(target)}"
                         )
                     ex.alias[target] = addr
+                    ex.solver.add(target == addr)
                     break
 
         return ex.alias.get(target)


### PR DESCRIPTION
remove the infeasible path check from the address alias resolution.

if the given path is infeasible, then the alias resolution result may be incorrect, but the feasible paths will be eventually ignored all together.

todo: prune infeasible paths before any potentially branching opcodes, to avoid unnecessary path explosion.