### PR TITLE
feat: nicer output

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -18,6 +18,7 @@ from .sevm import *
 from .utils import (
     create_solver,
     hexify,
+    stringify,
     indent_text,
     NamedTimer,
     yellow,
@@ -1066,14 +1067,14 @@ def to_str_model(model: Model, print_full_model: bool) -> StrModel:
         return name.startswith("p_") or name.startswith("halmos_")
 
     select_model = filter(select, model) if not print_full_model else model
-    return {str(decl): hexify(model[decl]) for decl in select_model}
+    return {str(decl): stringify(str(decl), model[decl]) for decl in select_model}
 
 
 def render_model(model: UnionType[str, StrModel]) -> str:
     if isinstance(model, str):
         return model
 
-    formatted = [f"\n    {decl} = {hexify(val)}" for decl, val in model.items()]
+    formatted = [f"\n    {decl} = {val}" for decl, val in model.items()]
     return "".join(sorted(formatted)) if formatted else "∅"
 
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -179,7 +179,7 @@ class halmos_cheat_code:
             raise HalmosException(f"bitsize larger than 256: {bits}")
 
         name = name_of(extract_string_argument(arg, 1))
-        return halmos_cheat_code.create_generic(ex, bits, name, f"int{bits}")
+        return int256(halmos_cheat_code.create_generic(ex, bits, name, f"int{bits}"))
 
     @staticmethod
     def create_int256(ex, arg):

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -71,11 +71,23 @@ class halmos_cheat_code:
     # bytes4(keccak256("createUint(uint256,string)"))
     create_uint: int = 0x66830DFA
 
+    # bytes4(keccak256("createUint256(string)"))
+    create_uint256: int = 0xBC7BEEFC
+
+    # bytes4(keccak256("createInt(uint256,string)"))
+    create_int: int = 0x49B9C7D4
+
+    # bytes4(keccak256("createInt256(string)"))
+    create_int256: int = 0xC2CE6AED
+
     # bytes4(keccak256("createBytes(uint256,string)"))
     create_bytes: int = 0xEEF5311D
 
-    # bytes4(keccak256("createUint256(string)"))
-    create_uint256: int = 0xBC7BEEFC
+    # bytes4(keccak256("createString(uint256,string)"))
+    create_string: int = 0xCE68656C
+
+    # bytes4(keccak256("createBytes4(string)"))
+    create_bytes4: int = 0xDE143925
 
     # bytes4(keccak256("createBytes32(string)"))
     create_bytes32: int = 0xBF72FA66

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -155,7 +155,7 @@ class halmos_cheat_code:
         return BitVec(label, BitVecSorts[bits])
 
     @staticmethod
-    def handle_create_uint(ex, arg):
+    def create_uint(ex, arg):
         bits = int_of(
             extract_bytes(arg, 4, 32), "symbolic bit size for halmos.createUint()"
         )
@@ -163,15 +163,15 @@ class halmos_cheat_code:
             raise HalmosException(f"bitsize larger than 256: {bits}")
 
         name = name_of(extract_string_argument(arg, 1))
-        return halmos_cheat_code.create_generic(ex, bits, name, f"uint{bits}")
+        return uint256(halmos_cheat_code.create_generic(ex, bits, name, f"uint{bits}"))
 
     @staticmethod
-    def handle_create_uint256(ex, arg):
+    def create_uint256(ex, arg):
         name = name_of(extract_string_argument(arg, 0))
         return halmos_cheat_code.create_generic(ex, 256, name, "uint256")
 
     @staticmethod
-    def handle_create_int(ex, arg):
+    def create_int(ex, arg):
         bits = int_of(
             extract_bytes(arg, 4, 32), "symbolic bit size for halmos.createUint()"
         )
@@ -182,12 +182,12 @@ class halmos_cheat_code:
         return halmos_cheat_code.create_generic(ex, bits, name, f"int{bits}")
 
     @staticmethod
-    def handle_create_int256(ex, arg):
+    def create_int256(ex, arg):
         name = name_of(extract_string_argument(arg, 0))
         return halmos_cheat_code.create_generic(ex, 256, name, "int256")
 
     @staticmethod
-    def handle_create_bytes(ex, arg):
+    def create_bytes(ex, arg):
         byte_size = int_of(
             extract_bytes(arg, 4, 32), "symbolic byte size for halmos.createBytes()"
         )
@@ -198,7 +198,7 @@ class halmos_cheat_code:
         return Concat(con(32), con(byte_size), symbolic_bytes)
 
     @staticmethod
-    def handle_create_string(ex, arg):
+    def create_string(ex, arg):
         byte_size = int_of(
             extract_bytes(arg, 4, 32), "symbolic byte size for halmos.createString()"
         )
@@ -209,36 +209,36 @@ class halmos_cheat_code:
         return Concat(con(32), con(byte_size), symbolic_string)
 
     @staticmethod
-    def handle_create_bytes4(ex, arg):
+    def create_bytes4(ex, arg):
         name = name_of(extract_string_argument(arg, 0))
         return uint256(halmos_cheat_code.create_generic(ex, 32, name, "bytes4"))
 
     @staticmethod
-    def handle_create_bytes32(ex, arg):
+    def create_bytes32(ex, arg):
         name = name_of(extract_string_argument(arg, 0))
         return halmos_cheat_code.create_generic(ex, 256, name, "bytes32")
 
     @staticmethod
-    def handle_create_address(ex, arg):
+    def create_address(ex, arg):
         name = name_of(extract_string_argument(arg, 0))
         return uint256(halmos_cheat_code.create_generic(ex, 160, name, "address"))
 
     @staticmethod
-    def handle_create_bool(ex, arg):
+    def create_bool(ex, arg):
         name = name_of(extract_string_argument(arg, 0))
         return uint256(halmos_cheat_code.create_generic(ex, 1, name, "bool"))
 
     handlers = {
-        0x66830DFA: handle_create_uint,  # createUint(uint256,string)
-        0xBC7BEEFC: handle_create_uint256,  # createUint256(string)
-        0x49B9C7D4: handle_create_int,  # createInt(uint256,string)
-        0xC2CE6AED: handle_create_int256,  # createInt256(string)
-        0xEEF5311D: handle_create_bytes,  # createBytes(uint256,string)
-        0xCE68656C: handle_create_string,  # createString(uint256,string)
-        0xDE143925: handle_create_bytes4,  # createBytes4(string)
-        0xBF72FA66: handle_create_bytes32,  # createBytes32(string)
-        0x3B0FA01B: handle_create_address,  # createAddress(string)
-        0x6E0BB659: handle_create_bool,  # createBool(string)
+        0x66830DFA: create_uint,  # createUint(uint256,string)
+        0xBC7BEEFC: create_uint256,  # createUint256(string)
+        0x49B9C7D4: create_int,  # createInt(uint256,string)
+        0xC2CE6AED: create_int256,  # createInt256(string)
+        0xEEF5311D: create_bytes,  # createBytes(uint256,string)
+        0xCE68656C: create_string,  # createString(uint256,string)
+        0xDE143925: create_bytes4,  # createBytes4(string)
+        0xBF72FA66: create_bytes32,  # createBytes32(string)
+        0x3B0FA01B: create_address,  # createAddress(string)
+        0x6E0BB659: create_bool,  # createBool(string)
     }
 
     @staticmethod

--- a/src/halmos/console.py
+++ b/src/halmos/console.py
@@ -1,0 +1,111 @@
+from z3 import BitVecRef
+
+from .utils import *
+
+
+def log_uint256(arg: BitVec) -> None:
+    b = extract_bytes(arg, 4, 32)
+    console.log(render_uint(b))
+
+
+def log_string(arg: BitVec) -> None:
+    str_val = extract_string_argument(arg, 0)
+    console.log(str_val)
+
+
+def log_bytes(arg: BitVec) -> None:
+    b = extract_bytes_argument(arg, 0)
+    console.log(render_bytes(b))
+
+
+def log_string_address(arg: BitVec) -> None:
+    str_val = extract_string_argument(arg, 0)
+    addr = extract_bytes(arg, 36, 32)
+    console.log(f"{str_val} {render_address(addr)}")
+
+
+def log_address(arg: BitVec) -> None:
+    addr = extract_bytes(arg, 4, 32)
+    console.log(render_address(addr))
+
+
+def log_string_bool(arg: BitVec) -> None:
+    str_val = extract_string_argument(arg, 0)
+    bool_val = extract_bytes(arg, 36, 32)
+    console.log(f"{str_val} {render_bool(bool_val)}")
+
+
+def log_bool(arg: BitVec) -> None:
+    bool_val = extract_bytes(arg, 4, 32)
+    console.log(render_bool(bool_val))
+
+
+def log_string_string(arg: BitVec) -> None:
+    str1_val = extract_string_argument(arg, 0)
+    str2_val = extract_string_argument(arg, 1)
+    console.log(f"{str1_val} {str2_val}")
+
+
+def log_bytes32(arg: BitVec) -> None:
+    b = extract_bytes(arg, 4, 32)
+    console.log(hexify(b))
+
+
+def log_string_int256(arg: BitVec) -> None:
+    str_val = extract_string_argument(arg, 0)
+    int_val = extract_bytes(arg, 36, 32)
+    console.log(f"{str_val} {render_int(int_val)}")
+
+
+def log_int256(arg: BitVec) -> None:
+    int_val = extract_bytes(arg, 4, 32)
+    console.log(render_int(int_val))
+
+
+def log_string_uint256(arg: BitVec) -> None:
+    str_val = extract_string_argument(arg, 0)
+    uint_val = extract_bytes(arg, 36, 32)
+    console.log(f"{str_val} {render_uint(uint_val)}")
+
+
+class console:
+    # see forge-std/console2.sol
+    address: BitVecRef = con_addr(0x000000000000000000636F6E736F6C652E6C6F67)
+
+    handlers = {
+        0xF82C50F1: log_uint256,
+        0xF5B1BBA9: log_uint256,  # alias for 'log(uint)'
+        0x41304FAC: log_string,
+        0x0BE77F56: log_bytes,
+        0x319AF333: log_string_address,
+        0x2C2ECBC2: log_address,
+        0xC3B55635: log_string_bool,
+        0x32458EED: log_bool,
+        0x4B5C4277: log_string_string,
+        0x27B7CF85: log_bytes32,
+        0x3CA6268E: log_string_int256,
+        0x2D5B6CB9: log_int256,
+        0xB60E72CC: log_string_uint256,
+    }
+
+    @staticmethod
+    def log(what: str) -> None:
+        print(f"[console.log] {magenta(what)}")
+
+    @staticmethod
+    def handle(ex, arg: BitVec) -> None:
+        try:
+            funsig: int = int_of(
+                extract_funsig(arg), "symbolic console function selector"
+            )
+
+            if handler := console.handlers.get(funsig):
+                return handler(arg)
+
+            info(
+                f"Unsupported console function: selector = 0x{funsig:0>8x}, "
+                f"calldata = {hexify(arg)}"
+            )
+        except Exception as e:
+            # we don't want to fail execution because of an issue during console.log
+            warn(f"console.handle: {repr(e)}")

--- a/src/halmos/console.py
+++ b/src/halmos/console.py
@@ -108,4 +108,4 @@ class console:
             )
         except Exception as e:
             # we don't want to fail execution because of an issue during console.log
-            warn(f"console.handle: {repr(e)}")
+            warn(f"console.handle: {repr(e)} with arg={hexify(arg)}")

--- a/src/halmos/exceptions.py
+++ b/src/halmos/exceptions.py
@@ -8,6 +8,14 @@ Note: this is a modified version execution-specs' src/ethereum/<fork>/vm/excepti
 """
 
 
+class HalmosException(Exception):
+    pass
+
+
+class NotConcreteError(HalmosException):
+    pass
+
+
 class EvmException(Exception):
     """
     Base class for all EVM exceptions.

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -22,7 +22,8 @@ from typing import (
 )
 from z3 import *
 
-from .cheatcodes import halmos_cheat_code, hevm_cheat_code, console, Prank
+from .cheatcodes import halmos_cheat_code, hevm_cheat_code, Prank
+from .console import console
 from .exceptions import *
 from .utils import *
 from .warnings import (

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import reduce
-from subprocess import Popen, PIPE
 from typing import (
     Any,
     Dict,
@@ -25,76 +24,19 @@ from z3 import *
 
 from .cheatcodes import halmos_cheat_code, hevm_cheat_code, console, Prank
 from .exceptions import *
-from .utils import (
-    assert_address,
-    assert_uint256,
-    bv_value_to_bytes,
-    byte_length,
-    color_info,
-    con_addr,
-    create_solver,
-    EVM,
-    hexify,
-    int_of,
-    restore_precomputed_hashes,
-    sha3_inv,
-    str_opcode,
-    unbox_int,
-)
+from .utils import *
 from .warnings import (
     warn,
     LIBRARY_PLACEHOLDER,
     INTERNAL_ERROR,
 )
 
-Word = Any  # z3 expression (including constants)
-Byte = Any  # z3 expression (including constants)
-Bytes = Any  # z3 expression (including constants)
-Address = BitVecRef  # 160-bitvector
 
 Steps = Dict[int, Dict[str, Any]]  # execution tree
 
 EMPTY_BYTES = b""
 MAX_CALL_DEPTH = 1024
 
-
-# dynamic BitVecSort sizes
-class BitVecSortCache:
-    def __init__(self):
-        self.cache = {}
-        for size in (
-            1,
-            8,
-            16,
-            32,
-            64,
-            128,
-            160,
-            256,
-            264,
-            288,
-            512,
-            544,
-            800,
-            1024,
-            1056,
-        ):
-            self.cache[size] = BitVecSort(size)
-
-    def __getitem__(self, size: int) -> BitVecSort:
-        hit = self.cache.get(size)
-        return hit if hit is not None else BitVecSort(size)
-
-
-BitVecSorts = BitVecSortCache()
-
-# known, fixed BitVecSort sizes
-BitVecSort1 = BitVecSorts[1]
-BitVecSort8 = BitVecSorts[8]
-BitVecSort160 = BitVecSorts[160]
-BitVecSort256 = BitVecSorts[256]
-BitVecSort264 = BitVecSorts[264]
-BitVecSort512 = BitVecSorts[512]
 
 # symbolic states
 # calldataload(index)
@@ -170,10 +112,6 @@ def id_str(x: Any) -> str:
     return hexify(x).replace(" ", "")
 
 
-def name_of(x: str) -> str:
-    return re.sub(r"\s+", "_", x)
-
-
 def padded_slice(lst: List, start: int, size: int, default=0) -> List:
     """
     Return a slice of lst, starting at start and with size elements. If the slice
@@ -222,38 +160,6 @@ def mnemonic(opcode) -> str:
         return str_opcode.get(opcode, hex(opcode))
     else:
         return str(opcode)
-
-
-def concat(args):
-    if len(args) > 1:
-        return Concat(args)
-    else:
-        return args[0]
-
-
-def uint256(x: BitVecRef) -> BitVecRef:
-    bitsize = x.size()
-    if bitsize > 256:
-        raise ValueError(x)
-    if bitsize == 256:
-        return x
-    return simplify(ZeroExt(256 - bitsize, x))
-
-
-def uint160(x: BitVecRef) -> BitVecRef:
-    bitsize = x.size()
-    if bitsize > 256:
-        raise ValueError(x)
-    if bitsize == 160:
-        return x
-    if bitsize > 160:
-        return simplify(Extract(159, 0, x))
-    else:
-        return simplify(ZeroExt(160 - bitsize, x))
-
-
-def con(n: int, size_bits=256) -> Word:
-    return BitVecVal(n, BitVecSorts[size_bits])
 
 
 def instruction_length(opcode: Any) -> int:
@@ -348,99 +254,6 @@ def wstore_bytes(
         if not eq(arr[i].sort(), BitVecSort8):
             raise ValueError(arr)
         mem[loc + i] = arr[i]
-
-
-def extract_bytes(data: BitVecRef, byte_offset: int, size_bytes: int) -> BitVecRef:
-    """Extract bytes from calldata. Zero-pad if out of bounds."""
-    n = data.size()
-    if n % 8 != 0:
-        raise ValueError(n)
-
-    # will extract hi - lo + 1 bits
-    hi = n - 1 - byte_offset * 8
-    lo = n - byte_offset * 8 - size_bytes * 8
-    lo = 0 if lo < 0 else lo
-
-    val = simplify(Extract(hi, lo, data))
-
-    zero_padding = size_bytes * 8 - val.size()
-    if zero_padding < 0:
-        raise ValueError(val)
-    if zero_padding > 0:
-        val = simplify(Concat(val, con(0, zero_padding)))
-
-    return val
-
-
-def extract_funsig(calldata: BitVecRef):
-    """Extracts the function signature (first 4 bytes) from calldata"""
-    return extract_bytes(calldata, 0, 4)
-
-
-def extract_string_argument(calldata: BitVecRef, arg_idx: int):
-    """Extracts idx-th argument of string from calldata"""
-    string_offset = int_of(
-        extract_bytes(calldata, 4 + arg_idx * 32, 32),
-        "symbolic offset for string argument",
-    )
-    string_length = int_of(
-        extract_bytes(calldata, 4 + string_offset, 32),
-        "symbolic size for string argument",
-    )
-    if string_length == 0:
-        return ""
-    string_value = int_of(
-        extract_bytes(calldata, 4 + string_offset + 32, string_length),
-        "symbolic string argument",
-    )
-    string_bytes = string_value.to_bytes(string_length, "big")
-    return string_bytes.decode("utf-8")
-
-
-def extract_string_array_argument(calldata: BitVecRef, arg_idx: int):
-    """Extracts idx-th argument of string array from calldata"""
-
-    array_slot = int_of(extract_bytes(calldata, 4 + 32 * arg_idx, 32))
-    num_strings = int_of(extract_bytes(calldata, 4 + array_slot, 32))
-
-    string_array = []
-
-    for i in range(num_strings):
-        string_offset = int_of(
-            extract_bytes(calldata, 4 + array_slot + 32 * (i + 1), 32)
-        )
-        string_length = int_of(
-            extract_bytes(calldata, 4 + array_slot + 32 + string_offset, 32)
-        )
-        string_value = int_of(
-            extract_bytes(
-                calldata, 4 + array_slot + 32 + string_offset + 32, string_length
-            )
-        )
-        string_bytes = string_value.to_bytes(string_length, "big")
-        string_array.append(string_bytes.decode("utf-8"))
-
-    return string_array
-
-
-def stringified_bytes_to_bytes(string_bytes: str):
-    """Converts a string of bytes to a bytes memory type"""
-
-    string_bytes_len = (len(string_bytes) + 1) // 2
-    string_bytes_len_enc = hex(string_bytes_len).replace("0x", "").rjust(64, "0")
-
-    string_bytes_len_ceil = (string_bytes_len + 31) // 32 * 32
-
-    ret_bytes = (
-        "00" * 31
-        + "20"
-        + string_bytes_len_enc
-        + string_bytes.ljust(string_bytes_len_ceil * 2, "0")
-    )
-    ret_len = len(ret_bytes) // 2
-    ret_bytes = bytes.fromhex(ret_bytes)
-
-    return BitVecVal(int.from_bytes(ret_bytes, "big"), ret_len * 8)
 
 
 @dataclass(frozen=True)
@@ -874,6 +687,15 @@ class Exec:  # an execution path
 
     def current_instruction(self) -> Instruction:
         return self.pgm.decode_instruction(self.pc)
+
+    def set_code(
+        self, who: Address, code: UnionType[bytes, BitVecRef, Contract]
+    ) -> None:
+        """
+        Sets the code at a given address.
+        """
+        assert_address(who)
+        self.code[who] = code if isinstance(code, Contract) else Contract(code)
 
     def str_cnts(self) -> str:
         return "".join(
@@ -1315,31 +1137,6 @@ class GenericStorage(Storage):
 
 
 SomeStorage = TypeVar("SomeStorage", bound=Storage)
-
-
-#             x  == b   if sort(x) = bool
-# int_to_bool(x) == b   if sort(x) = int
-def test(x: Word, b: bool) -> Word:
-    if is_bool(x):
-        if b:
-            return x
-        else:
-            return Not(x)
-    elif is_bv(x):
-        if b:
-            return x != con(0)
-        else:
-            return x == con(0)
-    else:
-        raise ValueError(x)
-
-
-def is_non_zero(x: Word) -> Word:
-    return test(x, True)
-
-
-def is_zero(x: Word) -> Word:
-    return test(x, False)
 
 
 def bitwise(op, x: Word, y: Word) -> Word:
@@ -1844,282 +1641,20 @@ class SEVM:
                 ex.solver.add(exit_code_var != con(0))
                 ret = arg
 
-            # TODO: factor out cheatcode semantics
             # halmos cheat code
             if eq(to, halmos_cheat_code.address):
                 ex.solver.add(exit_code_var != con(0))
-
-                funsig: int = int_of(
-                    extract_funsig(arg), "symbolic halmos cheatcode function selector"
-                )
-
-                if self.options.get("debug"):
-                    print(f"Executing halmos cheat code: {hex(funsig)}")
-
-                # createUint(uint256,string) returns (uint256)
-                if funsig == halmos_cheat_code.create_uint:
-                    bit_size = int_of(
-                        extract_bytes(arg, 4, 32),
-                        "symbolic bit size for halmos.createUint()",
-                    )
-                    name = name_of(extract_string_argument(arg, 1))
-                    if bit_size <= 256:
-                        label = f"halmos_{name}_uint{bit_size}_{ex.new_symbol_id():>02}"
-                        ret = uint256(BitVec(label, BitVecSorts[bit_size]))
-                    else:
-                        raise HalmosException(f"bitsize larger than 256: {bit_size}")
-
-                # createBytes(uint256,string) returns (bytes)
-                elif funsig == halmos_cheat_code.create_bytes:
-                    byte_size = int_of(
-                        extract_bytes(arg, 4, 32),
-                        "symbolic byte size for halmos.createBytes()",
-                    )
-                    name = name_of(extract_string_argument(arg, 1))
-                    label = f"halmos_{name}_bytes_{ex.new_symbol_id():>02}"
-                    symbolic_bytes = BitVec(label, BitVecSorts[byte_size * 8])
-                    ret = Concat(con(32), con(byte_size), symbolic_bytes)
-
-                # createUint256(string) returns (uint256)
-                elif funsig == halmos_cheat_code.create_uint256:
-                    name = name_of(extract_string_argument(arg, 0))
-                    label = f"halmos_{name}_uint256_{ex.new_symbol_id():>02}"
-                    ret = BitVec(label, BitVecSort256)
-
-                # createBytes32(string) returns (bytes32)
-                elif funsig == halmos_cheat_code.create_bytes32:
-                    name = name_of(extract_string_argument(arg, 0))
-                    label = f"halmos_{name}_bytes32_{ex.new_symbol_id():>02}"
-                    ret = BitVec(label, BitVecSort256)
-
-                # createAddress(string) returns (address)
-                elif funsig == halmos_cheat_code.create_address:
-                    name = name_of(extract_string_argument(arg, 0))
-                    label = f"halmos_{name}_address_{ex.new_symbol_id():>02}"
-                    ret = uint256(BitVec(label, BitVecSort160))
-
-                # createBool(string) returns (bool)
-                elif funsig == halmos_cheat_code.create_bool:
-                    name = name_of(extract_string_argument(arg, 0))
-                    label = f"halmos_{name}_bool_{ex.new_symbol_id():>02}"
-                    ret = uint256(BitVec(label, BitVecSort1))
-
-                else:
-                    error_msg = f"Unknown halmos cheat code: function selector = 0x{funsig:0>8x}, calldata = {hexify(arg)}"
-                    raise HalmosException(error_msg)
+                ret = halmos_cheat_code.handle(ex, arg)
 
             # vm cheat code
             if eq(to, hevm_cheat_code.address):
                 ex.solver.add(exit_code_var != con(0))
-                # vm.fail()
-                # BitVecVal(hevm_cheat_code.fail_payload, 800)
-                if arg == hevm_cheat_code.fail_payload:
-                    raise FailCheatcode()
-
-                # vm.assume(bool)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.assume_sig
-                ):
-                    assume_cond = simplify(is_non_zero(Extract(255, 0, arg)))
-                    ex.solver.add(assume_cond)
-                    ex.path.append(str(assume_cond))
-
-                # vm.getCode(string)
-                elif (
-                    simplify(Extract(arg_size * 8 - 1, arg_size * 8 - 32, arg))
-                    == hevm_cheat_code.get_code_sig
-                ):
-                    calldata = bytes.fromhex(hex(arg.as_long())[2:])
-                    path_len = int.from_bytes(calldata[36:68], "big")
-                    path = calldata[68 : 68 + path_len].decode("utf-8")
-
-                    if ":" in path:
-                        [filename, contract_name] = path.split(":")
-                        path = "out/" + filename + "/" + contract_name + ".json"
-
-                    target = self.options["target"].rstrip("/")
-                    path = target + "/" + path
-
-                    with open(path) as f:
-                        artifact = json.loads(f.read())
-
-                    if artifact["bytecode"]["object"]:
-                        bytecode = artifact["bytecode"]["object"].replace("0x", "")
-                    else:
-                        bytecode = artifact["bytecode"].replace("0x", "")
-
-                    ret = stringified_bytes_to_bytes(bytecode)
-                # vm.prank(address)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.prank_sig
-                ):
-                    result = ex.prank.prank(uint160(Extract(255, 0, arg)))
-                    if not result:
-                        raise HalmosException("You have an active prank already.")
-
-                # vm.startPrank(address)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg))
-                    == hevm_cheat_code.start_prank_sig
-                ):
-                    result = ex.prank.startPrank(uint160(Extract(255, 0, arg)))
-                    if not result:
-                        raise HalmosException("You have an active prank already.")
-
-                # vm.stopPrank()
-                elif (
-                    eq(arg.sort(), BitVecSorts[4 * 8])
-                    and simplify(Extract(31, 0, arg)) == hevm_cheat_code.stop_prank_sig
-                ):
-                    ex.prank.stopPrank()
-                # vm.deal(address,uint256)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32 * 2) * 8])
-                    and simplify(Extract(543, 512, arg)) == hevm_cheat_code.deal_sig
-                ):
-                    who = uint160(Extract(511, 256, arg))
-                    amount = simplify(Extract(255, 0, arg))
-                    ex.balance_update(who, amount)
-                # vm.store(address,bytes32,bytes32)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32 * 3) * 8])
-                    and simplify(Extract(799, 768, arg)) == hevm_cheat_code.store_sig
-                ):
-                    store_account = uint160(Extract(767, 512, arg))
-                    store_slot = simplify(Extract(511, 256, arg))
-                    store_value = simplify(Extract(255, 0, arg))
-                    store_account_addr = self.resolve_address_alias(ex, store_account)
-                    if store_account_addr is not None:
-                        self.sstore(ex, store_account_addr, store_slot, store_value)
-                    else:
-                        raise HalmosException(f"uninitialized account: {store_account}")
-
-                # vm.load(address,bytes32)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32 * 2) * 8])
-                    and simplify(Extract(543, 512, arg)) == hevm_cheat_code.load_sig
-                ):
-                    load_account = uint160(Extract(511, 256, arg))
-                    load_slot = simplify(Extract(255, 0, arg))
-                    load_account_addr = self.resolve_address_alias(ex, load_account)
-                    if load_account_addr is not None:
-                        ret = self.sload(ex, load_account_addr, load_slot)
-                    else:
-                        raise HalmosException(f"uninitialized account: {store_account}")
-
-                # vm.fee(uint256)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.fee_sig
-                ):
-                    ex.block.basefee = simplify(Extract(255, 0, arg))
-                # vm.chainId(uint256)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.chainid_sig
-                ):
-                    ex.block.chainid = simplify(Extract(255, 0, arg))
-                # vm.coinbase(address)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.coinbase_sig
-                ):
-                    ex.block.coinbase = uint160(Extract(255, 0, arg))
-                # vm.difficulty(uint256)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg))
-                    == hevm_cheat_code.difficulty_sig
-                ):
-                    ex.block.difficulty = simplify(Extract(255, 0, arg))
-                # vm.roll(uint256)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.roll_sig
-                ):
-                    ex.block.number = simplify(Extract(255, 0, arg))
-                # vm.warp(uint256)
-                elif (
-                    eq(arg.sort(), BitVecSorts[(4 + 32) * 8])
-                    and simplify(Extract(287, 256, arg)) == hevm_cheat_code.warp_sig
-                ):
-                    ex.block.timestamp = simplify(Extract(255, 0, arg))
-                # vm.etch(address,bytes)
-                elif extract_funsig(arg) == hevm_cheat_code.etch_sig:
-                    who = extract_bytes(arg, 4 + 12, 20)
-
-                    # who must be concrete
-                    if not is_bv_value(who):
-                        error_msg = f"vm.etch(address who, bytes code) must have concrete argument `who` but received {who}"
-                        raise HalmosException(error_msg)
-
-                    # code must be concrete
-                    try:
-                        code_offset = int_of(extract_bytes(arg, 4 + 32, 32))
-                        code_length = int_of(extract_bytes(arg, 4 + code_offset, 32))
-                        code_int = int_of(
-                            extract_bytes(arg, 4 + code_offset + 32, code_length)
-                        )
-                        code_bytes = code_int.to_bytes(code_length, "big")
-
-                        ex.code[who] = Contract(code_bytes)
-                    except Exception as e:
-                        error_msg = f"vm.etch(address who, bytes code) must have concrete argument `code` but received calldata {arg}"
-                        raise HalmosException(error_msg) from e
-                # ffi(string[]) returns (bytes)
-                elif extract_funsig(arg) == hevm_cheat_code.ffi_sig:
-                    if not self.options.get("ffi"):
-                        error_msg = "ffi cheatcode is disabled. Run again with `--ffi` if you want to enable it"
-                        raise HalmosException(error_msg)
-                    cmd = extract_string_array_argument(arg, 0)
-                    process = Popen(cmd, stdout=PIPE, stderr=PIPE)
-
-                    (stdout, stderr) = process.communicate()
-
-                    if stderr:
-                        warn(
-                            INTERNAL_ERROR,
-                            f"An exception has occurred during the usage of the ffi cheatcode:\n{stderr.decode('utf-8')}",
-                        )
-
-                    out_bytes = stdout.decode("utf-8")
-
-                    if not out_bytes.startswith("0x"):
-                        out_bytes = out_bytes.strip().encode("utf-8").hex()
-                    else:
-                        out_bytes = out_bytes.strip().replace("0x", "")
-
-                    ret = stringified_bytes_to_bytes(out_bytes)
-
-                else:
-                    # TODO: support other cheat codes
-                    msg = f"Unsupported cheat code: calldata = {hexify(arg)}"
-                    raise HalmosException(msg)
+                ret = hevm_cheat_code.handle(self, ex, arg)
 
             # console
             if eq(to, console.address):
                 ex.solver.add(exit_code_var != con(0))
-
-                funsig: int = int_of(
-                    extract_funsig(arg), "symbolic console function selector"
-                )
-
-                if funsig == console.log_uint256:
-                    print(extract_bytes(arg, 4, 32))
-
-                # elif funsig == console.log_string:
-
-                else:
-                    # TODO: support other console functions
-                    print(
-                        color_info(
-                            f"Unsupported console function: selector = 0x{funsig:0>8x}, "
-                            f"calldata = {hexify(arg)}"
-                        )
-                    )
+                console.handle(ex, arg)
 
             # store return value
             if ret_size > 0:

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -10,6 +10,108 @@ from z3 import *
 from .exceptions import NotConcreteError
 
 
+Word = Any  # z3 expression (including constants)
+Byte = Any  # z3 expression (including constants)
+Bytes = Any  # z3 expression (including constants)
+Address = BitVecRef  # 160-bitvector
+
+
+# dynamic BitVecSort sizes
+class BitVecSortCache:
+    def __init__(self):
+        self.cache = {}
+        for size in (
+            1,
+            8,
+            16,
+            32,
+            64,
+            128,
+            160,
+            256,
+            264,
+            288,
+            512,
+            544,
+            800,
+            1024,
+            1056,
+        ):
+            self.cache[size] = BitVecSort(size)
+
+    def __getitem__(self, size: int) -> BitVecSort:
+        hit = self.cache.get(size)
+        return hit if hit is not None else BitVecSort(size)
+
+
+BitVecSorts = BitVecSortCache()
+
+# known, fixed BitVecSort sizes
+BitVecSort1 = BitVecSorts[1]
+BitVecSort8 = BitVecSorts[8]
+BitVecSort160 = BitVecSorts[160]
+BitVecSort256 = BitVecSorts[256]
+BitVecSort264 = BitVecSorts[264]
+BitVecSort512 = BitVecSorts[512]
+
+
+def concat(args):
+    if len(args) > 1:
+        return Concat(args)
+    else:
+        return args[0]
+
+
+def uint256(x: BitVecRef) -> BitVecRef:
+    bitsize = x.size()
+    if bitsize > 256:
+        raise ValueError(x)
+    if bitsize == 256:
+        return x
+    return simplify(ZeroExt(256 - bitsize, x))
+
+
+def uint160(x: BitVecRef) -> BitVecRef:
+    bitsize = x.size()
+    if bitsize > 256:
+        raise ValueError(x)
+    if bitsize == 160:
+        return x
+    if bitsize > 160:
+        return simplify(Extract(159, 0, x))
+    else:
+        return simplify(ZeroExt(160 - bitsize, x))
+
+
+def con(n: int, size_bits=256) -> Word:
+    return BitVecVal(n, BitVecSorts[size_bits])
+
+
+#             x  == b   if sort(x) = bool
+# int_to_bool(x) == b   if sort(x) = int
+def test(x: Word, b: bool) -> Word:
+    if is_bool(x):
+        if b:
+            return x
+        else:
+            return Not(x)
+    elif is_bv(x):
+        if b:
+            return x != con(0)
+        else:
+            return x == con(0)
+    else:
+        raise ValueError(x)
+
+
+def is_non_zero(x: Word) -> Word:
+    return test(x, True)
+
+
+def is_zero(x: Word) -> Word:
+    return test(x, False)
+
+
 def create_solver(logic="QF_AUFBV", ctx=None, timeout=0, max_memory=0):
     # QF_AUFBV: quantifier-free bitvector + array theory: https://smtlib.cs.uiowa.edu/logics.shtml
     solver = SolverFor(logic, ctx=ctx)
@@ -22,6 +124,33 @@ def create_solver(logic="QF_AUFBV", ctx=None, timeout=0, max_memory=0):
         solver.set(max_memory=max_memory)
 
     return solver
+
+
+def extract_bytes(data: BitVecRef, byte_offset: int, size_bytes: int) -> BitVecRef:
+    """Extract bytes from calldata. Zero-pad if out of bounds."""
+    n = data.size()
+    if n % 8 != 0:
+        raise ValueError(n)
+
+    # will extract hi - lo + 1 bits
+    hi = n - 1 - byte_offset * 8
+    lo = n - byte_offset * 8 - size_bytes * 8
+    lo = 0 if lo < 0 else lo
+
+    val = simplify(Extract(hi, lo, data))
+
+    zero_padding = size_bytes * 8 - val.size()
+    if zero_padding < 0:
+        raise ValueError(val)
+    if zero_padding > 0:
+        val = simplify(Concat(val, con(0, zero_padding)))
+
+    return val
+
+
+def extract_funsig(calldata: BitVecRef):
+    """Extracts the function signature (first 4 bytes) from calldata"""
+    return extract_bytes(calldata, 0, 4)
 
 
 def bv_value_to_bytes(x: BitVecNumRef) -> bytes:
@@ -113,7 +242,7 @@ def stringify(symbol_name: str, val: Any):
         return f"0x{val.as_long():0{byte_length(val) * 2}x}"
     elif type_name == "bool":
         return str(val.as_long() != 0).lower()
-    elif type_name == "string":
+    elif type_name == "string" or "string" in symbol_name:  # XXX TEMP HACK
         str_val = bytes.fromhex(hexify(val)[2:]).decode("utf-8")
         return f'"{str_val}"'
     elif type_name == "bytes":

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -71,6 +71,15 @@ def uint256(x: BitVecRef) -> BitVecRef:
     return simplify(ZeroExt(256 - bitsize, x))
 
 
+def int256(x: BitVecRef) -> BitVecRef:
+    bitsize = x.size()
+    if bitsize > 256:
+        raise ValueError(x)
+    if bitsize == 256:
+        return x
+    return simplify(SignExt(256 - bitsize, x))
+
+
 def uint160(x: BitVecRef) -> BitVecRef:
     bitsize = x.size()
     if bitsize > 256:

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -336,6 +336,15 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_log_undecodable_string()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_log_unsupported()",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -871,6 +871,42 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_createBytes4()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createInt()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createInt256()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createString()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_createUint()",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -273,7 +273,70 @@
         ],
         "test/Console.t.sol:ConsoleTest": [
             {
-                "name": "check_log()",
+                "name": "check_log_address()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_bool()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_bytes()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_bytes32()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_int()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_string()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_uint()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_log_unsupported()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/regression/remappings.txt
+++ b/tests/regression/remappings.txt
@@ -1,2 +1,3 @@
 openzeppelin/=../lib/openzeppelin-contracts/contracts/
 ds-test/=../lib/forge-std/lib/ds-test/src/
+forge-std/=../lib/forge-std/src/

--- a/tests/regression/test/Console.t.sol
+++ b/tests/regression/test/Console.t.sol
@@ -2,10 +2,72 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
 
 contract ConsoleTest is Test {
-    function check_log() public view {
-        console.log(0);
-        console.log(1);
+    function test_log_uint() public view {
+        console2.log("this is 0:", uint256(0));
+        console2.log("this is 1:", uint256(1));
+
+        console2.log(uint256(0));
+        console2.log(uint256(1));
+
+        console2.logUint(0);
+        console2.logUint(1);
+    }
+
+    function test_log_int() public view {
+        console2.log("this is -1:", -1);
+        console2.log("this is 1:", int256(1));
+
+        console2.log(-1);
+        console2.log(int256(1));
+
+        console2.logInt(-1);
+        console2.logInt(int256(1));
+    }
+
+    function test_log_bytes() public view {
+        console2.log("this is hello (bytes):", "hello");
+        console2.log("this is empty bytes:", "");
+
+        console2.logBytes("hello");
+        console2.logBytes("");
+    }
+
+    function test_log_bytes32() public view {
+        console2.log("this is keccak256(hello):");
+        console2.logBytes32(keccak256("hello"));
+
+        console2.log("this is keccak256():");
+        console2.logBytes32(keccak256(""));
+    }
+
+    function test_log_address() public view {
+        console2.log("this is address(0):", address(0));
+        console2.log("this is address(this):", address(this));
+
+        console2.log(address(0));
+        console2.log(address(this));
+    }
+
+    function test_log_bool() public view {
+        console2.log("this is true:", true);
+        console2.log("this is false:", false);
+
+        console2.log(true);
+        console2.log(false);
+    }
+
+    function test_log_string() public view {
+        console2.log("this is hello (string):", "hello");
+        console2.log("this is empty string:", "");
+
+        console2.log("hello");
+        console2.log("");
+    }
+
+    function test_log_unsupported() public {
+        console2._sendLogPayload(abi.encodeWithSignature("doesNotExist()"));
     }
 }

--- a/tests/regression/test/Console.t.sol
+++ b/tests/regression/test/Console.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 import {console2} from "forge-std/console2.sol";
 
 contract ConsoleTest is Test {
-    function test_log_uint() public view {
+    function check_log_uint() public view {
         console2.log("this is 0:", uint256(0));
         console2.log("this is 1:", uint256(1));
 
@@ -16,7 +16,7 @@ contract ConsoleTest is Test {
         console2.logUint(1);
     }
 
-    function test_log_int() public view {
+    function check_log_int() public view {
         console2.log("this is -1:", -1);
         console2.log("this is 1:", int256(1));
 
@@ -27,15 +27,16 @@ contract ConsoleTest is Test {
         console2.logInt(int256(1));
     }
 
-    function test_log_bytes() public view {
-        console2.log("this is hello (bytes):", "hello");
-        console2.log("this is empty bytes:", "");
-
-        console2.logBytes("hello");
-        console2.logBytes("");
+    function check_log_bytes() public view {
+        bytes memory hello = "hello";
+        bytes memory empty = "";
+        console2.log("this is hello (bytes):");
+        console2.logBytes(hello);
+        console2.log("this is empty bytes:");
+        console2.logBytes(empty);
     }
 
-    function test_log_bytes32() public view {
+    function check_log_bytes32() public view {
         console2.log("this is keccak256(hello):");
         console2.logBytes32(keccak256("hello"));
 
@@ -43,7 +44,7 @@ contract ConsoleTest is Test {
         console2.logBytes32(keccak256(""));
     }
 
-    function test_log_address() public view {
+    function check_log_address() public view {
         console2.log("this is address(0):", address(0));
         console2.log("this is address(this):", address(this));
 
@@ -51,7 +52,7 @@ contract ConsoleTest is Test {
         console2.log(address(this));
     }
 
-    function test_log_bool() public view {
+    function check_log_bool() public view {
         console2.log("this is true:", true);
         console2.log("this is false:", false);
 
@@ -59,15 +60,17 @@ contract ConsoleTest is Test {
         console2.log(false);
     }
 
-    function test_log_string() public view {
-        console2.log("this is hello (string):", "hello");
-        console2.log("this is empty string:", "");
+    function check_log_string() public view {
+        string memory hello = "hello";
+        string memory empty = "";
+        console2.log("this is hello (string):", hello);
+        console2.log("this is empty string:", empty);
 
-        console2.log("hello");
-        console2.log("");
+        console2.log(hello);
+        console2.log(empty);
     }
 
-    function test_log_unsupported() public {
+    function check_log_unsupported() public {
         console2._sendLogPayload(abi.encodeWithSignature("doesNotExist()"));
     }
 }

--- a/tests/regression/test/Console.t.sol
+++ b/tests/regression/test/Console.t.sol
@@ -70,6 +70,12 @@ contract ConsoleTest is Test {
         console2.log(empty);
     }
 
+    function check_log_undecodable_string() public view {
+        bytes memory badBytes = hex"ff";
+        string memory bad = string(badBytes);
+        console2.log("this is a string that won't decode to utf-8:", bad);
+    }
+
     function check_log_unsupported() public {
         console2._sendLogPayload(abi.encodeWithSignature("doesNotExist()"));
     }

--- a/tests/regression/test/HalmosCheatCode.t.sol
+++ b/tests/regression/test/HalmosCheatCode.t.sol
@@ -13,6 +13,15 @@ contract HalmosCheatCodeTest is SymTest {
         assert(0 <= z && z <= type(uint8).max);
     }
 
+    function check_createInt() public {
+        int x = svm.createInt(256, 'x');
+        int y = svm.createInt(160, 'y');
+        int z = svm.createInt(8, 'z');
+        assert(type(int256).min <= x && x <= type(int256).max);
+        assert(type(int160).min <= y && y <= type(int160).max);
+        assert(type(int8).min <= z && z <= type(int8).max);
+    }
+
     function check_createBytes() public {
         bytes memory data = svm.createBytes(2, 'data');
         uint x = uint(uint8(data[0]));
@@ -21,14 +30,32 @@ contract HalmosCheatCodeTest is SymTest {
         assert(0 <= y && y <= type(uint8).max);
     }
 
+    function check_createString() public {
+        string memory data = svm.createString(5, 'str');
+        assert(bytes(data).length == 5);
+    }
+
     function check_createUint256() public {
         uint x = svm.createUint256('x');
         assert(0 <= x && x <= type(uint256).max);
     }
 
+    function check_createInt256() public {
+        int x = svm.createInt256('x');
+        assert(type(int256).min <= x && x <= type(int256).max);
+    }
+
     function check_createBytes32() public {
         bytes32 x = svm.createBytes32('x');
         assert(0 <= uint(x) && uint(x) <= type(uint256).max);
+        uint y; assembly { y := x }
+        assert(0 <= y && y <= type(uint256).max);
+    }
+
+    function check_createBytes4() public {
+        bytes4 x = svm.createBytes4('x');
+        uint256 x_uint = uint256(uint32(x));
+        assert(0 <= x_uint && x_uint <= type(uint32).max);
         uint y; assembly { y := x }
         assert(0 <= y && y <= type(uint256).max);
     }


### PR DESCRIPTION
Includes a bunch of things:
- type based counterexample rendering (different rendering for uints, signed ints, address, bool, bytes, string, bytes32...)
- console.log functions leverage the same type based rendering
- includes a bunch of new console.log functions + tests
- updates to latest halmos-cheatcode, implements the new cheatcodes (createInt, createInt256, createBytes4, createString) and add tests for these functions

Plus some internal reorganizing:
- move utils-like functions from sevm.py to utils.py
- move cheatcode and console.log handling logic from sevm.py to cheatcodes.py
- switch to a lookup+handler based mechanism in console and halmos_cheat_code
