### PR TITLE
ffi: decode output as hex if it looks like a hexstring

### DIFF
--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -3,7 +3,7 @@
 import re
 
 from timeit import default_timer as timer
-from typing import Dict, Tuple, Any, Union as UnionType
+from typing import Dict, Tuple, Any, Optional, Union as UnionType
 
 from z3 import *
 
@@ -225,6 +225,16 @@ def byte_length(x: Any) -> int:
         return len(x)
 
     raise ValueError(x)
+
+
+def decode_hex(hexstring: str) -> Optional[bytes]:
+    if hexstring.startswith("0x"):
+        hexstring = hexstring[2:]
+    try:
+        # not checking if length is even because fromhex accepts spaces
+        return bytes.fromhex(hexstring)
+    except ValueError:
+        return None
 
 
 def hexify(x):

--- a/tests/expected/ffi.json
+++ b/tests/expected/ffi.json
@@ -21,6 +21,15 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_ImplicitHexStringOutput()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_Stderr()",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/ffi/test/Ffi.t.sol
+++ b/tests/ffi/test/Ffi.t.sol
@@ -19,6 +19,18 @@ contract FfiTest is Test {
         assert(expected == output);
     }
 
+    function check_ImplicitHexStringOutput() public {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "echo";
+        inputs[1] = "-n";
+        inputs[2] = " 4243 ";
+
+        bytes memory res = vm.ffi(inputs);
+        assertEq(res.length, 2);
+        assert(res[0] == 0x42);
+        assert(res[1] == 0x43);
+    }
+
     function check_StringOutput() public {
         string memory str = "arbitrary string";
 


### PR DESCRIPTION
This is for compatibility with foundry, and will work better with tools like huffc that output hexstrings without a 0x prefix. For instance:

    function deployHuff(string memory srcFile) internal returns (address deployedAddress) {
        string[] memory command = new string[](3);
        command[0] = "huffc";
        command[1] = "--bytecode";
        command[2] = srcFile;

        bytes memory bytecode = vm.ffi(command);

        assembly {
            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
        }
    }

Before this commit, bytecode was the hexstring. After this commit, bytecode is the actual bytes.