### PR TITLE
ci: disable long and external tests from pull request build

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -3,8 +3,9 @@ name: Test external projects
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+# pull_request:
+#   branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -3,8 +3,9 @@ name: Test long
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+# pull_request:
+#   branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
disable the long and external tests in the pull request build.  they should now be executed manually, e.g., before merging the pr.