### PR TITLE
test: increase branching timeout for setup of token tests

### DIFF
--- a/examples/tokens/ERC20/test/CurveTokenV3.t.sol
+++ b/examples/tokens/ERC20/test/CurveTokenV3.t.sol
@@ -33,6 +33,7 @@ contract CurveTokenV3Test is ERC20Test {
     CurveTokenV3 token_;
     address minter;
 
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         token = address(new EmptyContract());
         // Source of Deployed Bytecode: https://etherscan.io/address/0x06325440D014e39736583c165C2963BA99fAf14E#code

--- a/examples/tokens/ERC20/test/DEIStablecoin.t.sol
+++ b/examples/tokens/ERC20/test/DEIStablecoin.t.sol
@@ -24,6 +24,7 @@ contract DEIStablecoinTest is ERC20Test {
     DEIStablecoin token_;
     address lossless;
 
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         token = address(new EmptyContract());
         // Source of Deployed Bytecode: https://etherscan.io/address/0x63c28e2ff796e1480eb9ac8c3c55dcb9ae7b3df6#code

--- a/examples/tokens/ERC20/test/OpenZeppelinERC20.t.sol
+++ b/examples/tokens/ERC20/test/OpenZeppelinERC20.t.sol
@@ -7,6 +7,8 @@ import {OpenZeppelinERC20} from "../src/OpenZeppelinERC20.sol";
 
 /// @custom:halmos --solver-timeout-assertion 0
 contract OpenZeppelinERC20Test is ERC20Test {
+
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         address deployer = address(0x1000);
 

--- a/examples/tokens/ERC20/test/SoladyERC20.t.sol
+++ b/examples/tokens/ERC20/test/SoladyERC20.t.sol
@@ -7,6 +7,8 @@ import {SoladyERC20} from "../src/SoladyERC20.sol";
 
 /// @custom:halmos --storage-layout=generic --solver-timeout-assertion 0
 contract SoladyERC20Test is ERC20Test {
+
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         address deployer = address(0x1000);
 

--- a/examples/tokens/ERC20/test/SolmateERC20.t.sol
+++ b/examples/tokens/ERC20/test/SolmateERC20.t.sol
@@ -7,6 +7,8 @@ import {SolmateERC20} from "../src/SolmateERC20.sol";
 
 /// @custom:halmos --solver-timeout-assertion 0
 contract SolmateERC20Test is ERC20Test {
+
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         address deployer = address(0x1000);
 

--- a/examples/tokens/ERC721/test/OpenZeppelinERC721.t.sol
+++ b/examples/tokens/ERC721/test/OpenZeppelinERC721.t.sol
@@ -7,6 +7,8 @@ import {OpenZeppelinERC721} from "../src/OpenZeppelinERC721.sol";
 
 /// @custom:halmos --solver-timeout-assertion 0
 contract OpenZeppelinERC721Test is ERC721Test {
+
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         deployer = address(0x1000);
 

--- a/examples/tokens/ERC721/test/SoladyERC721.t.sol
+++ b/examples/tokens/ERC721/test/SoladyERC721.t.sol
@@ -7,6 +7,8 @@ import {SoladyERC721} from "../src/SoladyERC721.sol";
 
 /// @custom:halmos --storage-layout=generic --solver-timeout-assertion 0
 contract SoladyERC721Test is ERC721Test {
+
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         deployer = address(0x1000);
 

--- a/examples/tokens/ERC721/test/SolmateERC721.t.sol
+++ b/examples/tokens/ERC721/test/SolmateERC721.t.sol
@@ -7,6 +7,8 @@ import {SolmateERC721} from "../src/SolmateERC721.sol";
 
 /// @custom:halmos --solver-timeout-assertion 0
 contract SolmateERC721Test is ERC721Test {
+
+    /// @custom:halmos --solver-timeout-branching 1000
     function setUp() public override {
         deployer = address(0x1000);
 


### PR DESCRIPTION
the setup of token tests involves initializing dynamic storage arrays.  computing the slots for dynamic array elements, in turn, requires arithmetic on keccak hash images.  although it is very unlikely, there is still a possibility of arithmetic overflow during the slot computation.  therefore, overflow checks for the slot computation are included in bytecode.  however, solving these overflow checking conditions is nontrivial, due to the hash images involved, making the default branching timeout (1ms) insufficient.  this leads to the exploration of infeasible paths, which could cause malfunction in loop detection.  increasing the branching timeout specifically during setup can address this issue, without incurring the performance overhead for executing main tests.

todo: the current approach wouldn't be effective if dynamic storage arrays are updated during the main tests.  a more robust solution would be to implement a query optimization that simplifies common arithmetics on hash images before they are sent to the solver.