### PR TITLE
breaking change: drop support for python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         parallel: ["", "--test-parallel"]
         storage-layout: ["solidity", "generic"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "z3-solver",
 ]
@@ -33,7 +33,7 @@ halmos = "halmos.__main__:main"
 "Homepage" = "https://github.com/a16z/halmos"
 
 [tool.black]
-target-versions = ["py38", "py39", "py310", "py311"]
+target-versions = ["py39", "py310", "py311"]
 
 [tool.pytest.ini_options]
 # TODO: re-add test_traces.py when we have a better way to support it in CI


### PR DESCRIPTION
end support for python 3.8 (which will reach its end of life in less than a year).

related: https://github.com/Z3Prover/z3/issues/7041