### PR TITLE
fix: trace generation for shared solver

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -256,7 +256,9 @@ def render_trace(context: CallContext, file=sys.stdout) -> None:
         # TODO: select verbosity level to render full initcode
         # initcode_str = rendered_initcode(context)
         initcode_str = f"<{byte_length(message.data)} bytes of initcode>"
-        print(f"{indent}{call_scheme_str}{addr_str}::{initcode_str}{value_str}", file=file)
+        print(
+            f"{indent}{call_scheme_str}{addr_str}::{initcode_str}{value_str}", file=file
+        )
 
     else:
         calldata = (

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -696,7 +696,8 @@ def run(
             if args.verbose >= 1:
                 print(f"Found potential path (id: {idx+1})")
 
-            traces[idx] = rendered_trace(ex.context)
+            if args.verbose >= VERBOSITY_TRACE_COUNTEREXAMPLE:
+                traces[idx] = rendered_trace(ex.context)
 
             query = ex.path.solver.to_smt2()
 
@@ -717,7 +718,8 @@ def run(
 
         elif ex.context.is_stuck():
             stuck.append((idx, ex, ex.context.get_stuck_reason()))
-            traces[idx] = rendered_trace(ex.context)
+            if args.print_blocked_states:
+                traces[idx] = rendered_trace(ex.context)
 
         elif not error:
             normal += 1

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -597,7 +597,7 @@ def run(
 
     solver = mk_solver(args)
     path = Path(solver)
-    path.extend(setup_ex.path.conditions)
+    path.extend_path(setup_ex.path)
 
     exs = sevm.run(
         Exec(
@@ -682,7 +682,7 @@ def run(
 
         if args.verbose >= VERBOSITY_TRACE_PATHS:
             print(f"Path #{idx+1}:")
-            print(indent_text(ex.str_path()))
+            print(indent_text(str(ex.path)))
 
             print("\nTrace:")
             render_trace(ex.context)

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -230,11 +230,9 @@ def rendered_log(log: EventLog) -> str:
 
 
 def rendered_trace(context: CallContext) -> str:
-    output = io.StringIO()
-    render_trace(context, file=output)
-    result = output.getvalue()
-    output.close()
-    return result
+    with io.StringIO() as output:
+        render_trace(context, file=output)
+        return output.getvalue()
 
 
 def render_trace(context: CallContext, file=sys.stdout) -> None:

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -188,7 +188,7 @@ def rendered_initcode(context: CallContext) -> str:
     return f"{initcode_str}({color_info(args_str)})"
 
 
-def render_output(context: CallContext) -> None:
+def render_output(context: CallContext, file=sys.stdout) -> None:
     output = context.output
     returndata_str = "0x"
     failed = output.error is not None
@@ -212,7 +212,8 @@ def render_output(context: CallContext) -> None:
     color = red if failed else green
     indent = context.depth * "    "
     print(
-        f"{indent}{color('↩ ')}{ret_scheme_str}{color(returndata_str)}{color(error_str)}"
+        f"{indent}{color('↩ ')}{ret_scheme_str}{color(returndata_str)}{color(error_str)}",
+        file=file,
     )
 
 
@@ -228,7 +229,15 @@ def rendered_log(log: EventLog) -> str:
     return f"{opcode_str}({args_str})"
 
 
-def render_trace(context: CallContext) -> None:
+def rendered_trace(context: CallContext) -> str:
+    output = io.StringIO()
+    render_trace(context, file=output)
+    result = output.getvalue()
+    output.close()
+    return result
+
+
+def render_trace(context: CallContext, file=sys.stdout) -> None:
     # TODO: label for known addresses
     # TODO: decode calldata
     # TODO: decode logs
@@ -247,7 +256,7 @@ def render_trace(context: CallContext) -> None:
         # TODO: select verbosity level to render full initcode
         # initcode_str = rendered_initcode(context)
         initcode_str = f"<{byte_length(message.data)} bytes of initcode>"
-        print(f"{indent}{call_scheme_str}{addr_str}::{initcode_str}{value_str}")
+        print(f"{indent}{call_scheme_str}{addr_str}::{initcode_str}{value_str}", file=file)
 
     else:
         calldata = (
@@ -258,21 +267,21 @@ def render_trace(context: CallContext) -> None:
 
         call_str = f"{addr_str}::{calldata}"
         static_str = yellow(" [static]") if message.is_static else ""
-        print(f"{indent}{call_scheme_str}{call_str}{static_str}{value_str}")
+        print(f"{indent}{call_scheme_str}{call_str}{static_str}{value_str}", file=file)
 
     log_indent = (context.depth + 1) * "    "
     for trace_element in context.trace:
         if isinstance(trace_element, CallContext):
-            render_trace(trace_element)
+            render_trace(trace_element, file=file)
         elif isinstance(trace_element, EventLog):
-            print(f"{log_indent}{rendered_log(trace_element)}")
+            print(f"{log_indent}{rendered_log(trace_element)}", file=file)
         else:
             raise HalmosException(f"unexpected trace element: {trace_element}")
 
-    render_output(context)
+    render_output(context, file=file)
 
     if context.depth == 1:
-        print()
+        print(file=file)
 
 
 def run_bytecode(hexcode: str, args: Namespace) -> List[Exec]:
@@ -630,6 +639,7 @@ def run(
     result_exs = []
     future_models = []
     counterexamples = []
+    traces = {}
 
     def future_callback(future_model):
         m = future_model.result()
@@ -663,7 +673,7 @@ def run(
                 if args.verbose == VERBOSITY_TRACE_PATHS
                 else "Trace:"
             )
-            render_trace(result_exs[index].context)
+            print(traces[index], end="")
 
     for idx, ex in enumerate(exs):
         result_exs.append(ex)
@@ -684,6 +694,8 @@ def run(
             if args.verbose >= 1:
                 print(f"Found potential path (id: {idx+1})")
 
+            traces[idx] = rendered_trace(ex.context)
+
             query = ex.path.solver.to_smt2()
 
             future_model = thread_pool.submit(
@@ -703,6 +715,7 @@ def run(
 
         elif ex.context.is_stuck():
             stuck.append((idx, ex, ex.context.get_stuck_reason()))
+            traces[idx] = rendered_trace(ex.context)
 
         elif not error:
             normal += 1
@@ -746,7 +759,7 @@ def run(
         warn(INTERNAL_ERROR, f"Encountered {err}")
         if args.print_blocked_states:
             print(f"\nPath #{idx+1}")
-            render_trace(ex.context)
+            print(traces[idx], end="")
 
     if logs.bounded_loops:
         warn(

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -647,16 +647,22 @@ class Path:
     # path constraints include both explicit branching conditions and implicit assumptions (eg, no hash collisions)
     # TODO: separate these two types of constraints, so that we can display only branching conditions to users
     conditions: List
+    branching: List  # indexes of conditions
     pending: List
 
     def __init__(self, solver: Solver):
         self.solver = solver
         self.num_scopes = 0
         self.conditions = []
+        self.branching = []
         self.pending = []
 
     def __deepcopy__(self, memo):
         raise NotImplementedError(f"use the branch() method instead of deepcopy()")
+
+    def __str__(self) -> str:
+        branching_conds = [self.conditions[idx] for idx in self.branching]
+        return "".join([f"- {cond}\n" for cond in branching_conds if str(cond) != "True"])
 
     def branch(self, cond):
         if len(self.pending) > 0:
@@ -692,10 +698,10 @@ class Path:
 
         self.solver.pop(self.solver.num_scopes() - self.num_scopes)
 
-        self.extend(self.pending)
+        self.extend(self.pending, branching=True)
         self.pending = []
 
-    def append(self, cond):
+    def append(self, cond, branching=False):
         cond = simplify(cond)
 
         if is_true(cond):
@@ -704,9 +710,16 @@ class Path:
         self.solver.add(cond)
         self.conditions.append(cond)
 
-    def extend(self, conds):
+        if branching:
+            self.branching.append(len(self.conditions) - 1)
+
+    def extend(self, conds, branching=False):
         for cond in conds:
-            self.append(cond)
+            self.append(cond, branching=branching)
+
+    def extend_path(self, path):
+        # branching conditions are not preserved
+        self.extend(path.conditions)
 
 
 class Exec:  # an execution path
@@ -831,14 +844,6 @@ class Exec:  # an execution path
             ]
         )
 
-    def str_path(self) -> str:
-        return "".join(
-            map(
-                lambda x: "- " + str(x) + "\n",
-                filter(lambda x: str(x) != "True", self.path.conditions),
-            )
-        )
-
     def __str__(self) -> str:
         output = self.context.output.data
         return hexify(
@@ -854,7 +859,7 @@ class Exec:  # an execution path
                             self.storage,
                         )
                     ),
-                    f"Path:\n{self.str_path()}",
+                    f"Path:\n{self.path}",
                     f"Aliases:\n",
                     "".join([f"- {k}: {v}\n" for k, v in self.alias.items()]),
                     f"Output: {output.hex() if isinstance(output, bytes) else output}\n",
@@ -2089,12 +2094,12 @@ class SEVM:
                 new_ex_true = self.create_branch(ex, cond_true, target)
             else:
                 new_ex_true = ex
-                new_ex_true.path.append(cond_true)
+                new_ex_true.path.append(cond_true, branching=True)
                 new_ex_true.pc = target
 
         if follow_false:
             new_ex_false = ex
-            new_ex_false.path.append(cond_false)
+            new_ex_false.path.append(cond_false, branching=True)
             new_ex_false.next_pc()
 
         if new_ex_true:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -662,7 +662,9 @@ class Path:
 
     def __str__(self) -> str:
         branching_conds = [self.conditions[idx] for idx in self.branching]
-        return "".join([f"- {cond}\n" for cond in branching_conds if str(cond) != "True"])
+        return "".join(
+            [f"- {cond}\n" for cond in branching_conds if str(cond) != "True"]
+        )
 
     def branch(self, cond):
         if len(self.pending) > 0:


### PR DESCRIPTION
#218 introduced new issues for trace generation:  rendering z3 objects might fail when the shared solver is used for another path context.

fix the issues by:
- generate traces in advance at the end of each path before switching to another path
- but generate traces only when the trace rendering flags are enabled
- maintain branching conditions separately, so that internal constraints don't appear in trace outputs