### PR TITLE
ci: cache pip wheels

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Install dependencies
         run: python -m pip install --upgrade pip

--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
use setup-python cache.  (since z3-solver 4.12.4, wheel is not cached natively in macos runners, taking ~20m to build every ci run.)

todo: check if `--upgrade --upgrade-strategy eager` is needed for `pip install -e .`