### PR TITLE
feat: add --match-test and --match-contract

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1328,6 +1328,20 @@ def build_output_iterator(build_out: Dict):
                 yield (build_out_map, filename, contract_name)
 
 
+def contract_regex(args):
+    if args.contract:
+        return f"^{args.contract}$"
+    else:
+        return args.match_contract
+
+
+def test_regex(args):
+    if args.match_test.startswith("^"):
+        return args.match_test
+    else:
+        return f"^{args.function}.*{args.match_test}"
+
+
 @dataclass(frozen=True)
 class MainResult:
     exitcode: int
@@ -1427,7 +1441,7 @@ def _main(_args=None) -> MainResult:
     #
 
     for build_out_map, filename, contract_name in build_output_iterator(build_out):
-        if args.contract and args.contract != contract_name:
+        if not re.search(contract_regex(args), contract_name):
             continue
 
         (contract_json, contract_type, natspec) = build_out_map[filename][contract_name]
@@ -1435,7 +1449,7 @@ def _main(_args=None) -> MainResult:
             continue
 
         methodIdentifiers = contract_json["methodIdentifiers"]
-        funsigs = [f for f in methodIdentifiers if re.search(args.function, f)]
+        funsigs = [f for f in methodIdentifiers if re.search(test_regex(args), f)]
         num_found = len(funsigs)
 
         if num_found == 0:
@@ -1489,9 +1503,11 @@ def _main(_args=None) -> MainResult:
         print(f"\n[time] {timer.report()}")
 
     if total_found == 0:
-        error_msg = f"Error: No tests with the prefix `{args.function}`"
-        if args.contract is not None:
-            error_msg += f" in {args.contract}"
+        error_msg = (
+            f"Error: No tests with"
+            + f" --match-contract '{contract_regex(args)}'"
+            + f" --match-test '{test_regex(args)}'"
+        )
         print(color_warn(error_msg))
         return MainResult(1)
 

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1435,7 +1435,7 @@ def _main(_args=None) -> MainResult:
             continue
 
         methodIdentifiers = contract_json["methodIdentifiers"]
-        funsigs = [f for f in methodIdentifiers if f.startswith(args.function)]
+        funsigs = [f for f in methodIdentifiers if re.search(args.function, f)]
         num_found = len(funsigs)
 
         if num_found == 0:

--- a/src/halmos/parser.py
+++ b/src/halmos/parser.py
@@ -18,13 +18,25 @@ def mk_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--contract",
         metavar="CONTRACT_NAME",
-        help="run tests in the given contract only",
+        help="run tests in the given contract. Shortcut for `--match-contract '^{NAME}$'`.",
+    )
+    parser.add_argument(
+        "--match-contract",
+        metavar="CONTRACT_NAME_REGEX",
+        default="",
+        help="run tests in contracts matching the given regex. Ignored if the --contract name is given. (default: '%(default)s')",
     )
     parser.add_argument(
         "--function",
         metavar="FUNCTION_NAME_PREFIX",
         default="check_",
-        help="run tests matching the given prefix only (default: %(default)s)",
+        help="run tests matching the given prefix. Shortcut for `--match-test '^{PREFIX}'`. (default: '%(default)s')",
+    )
+    parser.add_argument(
+        "--match-test",
+        metavar="FUNCTION_NAME_REGEX",
+        default="^check_",
+        help="run tests matching the given regex. The --function prefix is automatically added, unless the regex starts with '^'. (default: '%(default)s')",
     )
 
     parser.add_argument(
@@ -55,7 +67,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
         metavar="SELECTOR1,SELECTOR2,...",
         # onERC721Received, IERC1271.isValidSignature
         default="0x150b7a02,0x1626ba7e",
-        help="use uninterpreted abstractions for unknown external calls with the given function signatures (default: %(default)s)",
+        help="use uninterpreted abstractions for unknown external calls with the given function signatures (default: '%(default)s')",
     )
     parser.add_argument(
         "--return-size-of-unknown-calls",
@@ -164,7 +176,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
         "--forge-build-out",
         metavar="DIRECTORY_NAME",
         default="out",
-        help="forge build artifacts directory name (default: %(default)s)",
+        help="forge build artifacts directory name (default: '%(default)s')",
     )
 
     # smt solver options
@@ -213,7 +225,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
         "--solver-subprocess-command",
         metavar="COMMAND",
         default="z3 -model",
-        help="use the given command for the subprocess solver (requires --solver-subprocess) (default: %(default)s)",
+        help="use the given command for the subprocess solver (requires --solver-subprocess) (default: '%(default)s')",
     )
     group_solver.add_argument(
         "--solver-parallel",

--- a/src/halmos/parser.py
+++ b/src/halmos/parser.py
@@ -37,7 +37,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
         "--match-test",
         "--mt",
         metavar="FUNCTION_NAME_REGEX",
-        default="^check_",
+        default="",
         help="run tests matching the given regex. The --function prefix is automatically added, unless the regex starts with '^'. (default: '%(default)s')",
     )
 

--- a/src/halmos/parser.py
+++ b/src/halmos/parser.py
@@ -22,6 +22,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--match-contract",
+        "--mc",
         metavar="CONTRACT_NAME_REGEX",
         default="",
         help="run tests in contracts matching the given regex. Ignored if the --contract name is given. (default: '%(default)s')",
@@ -34,6 +35,7 @@ def mk_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--match-test",
+        "--mt",
         metavar="FUNCTION_NAME_REGEX",
         default="^check_",
         help="run tests matching the given regex. The --function prefix is automatically added, unless the regex starts with '^'. (default: '%(default)s')",


### PR DESCRIPTION
add --match-test REGEX:
- the `--function PREFIX` is now a shortcut for `--match-test ^{PREFIX}`.
- unless REGEX starts with `^`, the prefix is automatically added, i.e., the final regex is `^{PREFIX}.*{REGEX}`.

add --match-contract REGEX:
- the `--contract NAME` is now a shortcut for `--match-contract ^{NAME}$`.
- ignored if `--contract` is given.

[subsume #211]