### PR TITLE
Add --build-info to forge build command

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1399,6 +1399,7 @@ def _main(_args=None) -> MainResult:
     build_cmd = [
         "forge",  # shutil.which('forge')
         "build",
+        "--build-info",
         "--root",
         args.root,
         "--extra-output",


### PR DESCRIPTION
Forge has recently (https://github.com/foundry-rs/foundry/pull/7197) dropped the ast from the build json by default, so we need to request it explicitly with `--ast`, `ast = <bool>` config or just `--build-info` to avoid checking if forge supports the `--ast` command