### PR TITLE
support for signing and verifying signatures

### DIFF
--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -535,7 +535,7 @@ class hevm_cheat_code:
                 for (_key, _digest), (_v, _r, _s) in known_sigs.items():
                     distinct = Implies(
                         Or(key != _key, digest != _digest),
-                        And(r != _r, s != _s),
+                        Or(v != _v, r != _r, s != _s),
                     )
                     ex.path.append(distinct)
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -501,6 +501,7 @@ class hevm_cheat_code:
 
             # TODO: handle concrete private key + digest (generate concrete signature)
             # TODO: do we want to constrain v to {27, 28}?
+            # TODO: do we want to constrain r and s to be less than curve order?
 
             # check for an existing signature
             known_sigs = ex.known_sigs

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -325,6 +325,9 @@ class hevm_cheat_code:
     # sign(uint256,bytes32)
     sign_sig: int = 0xE341EAA4
 
+    # label(address,string)
+    label_sig: int = 0xC657C718
+
     @staticmethod
     def handle(sevm, ex, arg: BitVec) -> BitVec:
         funsig: int = int_of(extract_funsig(arg), "symbolic hevm cheatcode")
@@ -535,6 +538,13 @@ class hevm_cheat_code:
                     ex.path.append(distinct)
 
             return Concat(uint256(v), r, s)
+
+        elif funsig == hevm_cheat_code.label_sig:
+            addr = extract_bytes(arg, 4, 32)
+            label = extract_string_argument(arg, 1)
+
+            # TODO: no-op for now
+            pass
 
         else:
             # TODO: support other cheat codes

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -530,6 +530,8 @@ class hevm_cheat_code:
                 ex.path.append(recover_malleable == addr)
 
                 # mark signatures as distinct if key or digest are distinct
+                # NOTE: the condition `And(r != _r, s != _s)` is stronger than `Or(v != _v, r != _r, s != _s)` which is sound
+                # TODO: we need to figure out whether this stronger condition is necessary and whether it could lead to unsound results in practical cases
                 for (_key, _digest), (_v, _r, _s) in known_sigs.items():
                     distinct = Implies(
                         Or(key != _key, digest != _digest),

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -153,10 +153,6 @@ def iter_bytes(x: Any, _byte_length: int = -1):
     raise ValueError(x)
 
 
-def is_concrete(x: Any) -> bool:
-    return isinstance(x, int) or isinstance(x, bytes) or is_bv_value(x)
-
-
 def mnemonic(opcode) -> str:
     if is_concrete(opcode):
         opcode = int_of(opcode)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -32,7 +32,6 @@ from .warnings import (
     INTERNAL_ERROR,
 )
 
-
 Steps = Dict[int, Dict[str, Any]]  # execution tree
 
 EMPTY_BYTES = b""
@@ -40,6 +39,7 @@ MAX_CALL_DEPTH = 1024
 
 # TODO: make this configurable
 MAX_MEMORY_SIZE = 2**20
+
 
 # symbolic states
 # calldataload(index)
@@ -58,11 +58,6 @@ f_gas = Function("gas", BitVecSort256, BitVecSort256)
 f_gasprice = Function("gasprice", BitVecSort256)
 # origin()
 f_origin = Function("origin", BitVecSort160)
-
-# ecrecover(digest, v, r, s)
-f_ecrecover = Function(
-    "ecrecover", BitVecSort256, BitVecSort8, BitVecSort256, BitVecSort256, BitVecSort160
-)
 
 # uninterpreted arithmetic
 f_div = Function("evm_bvudiv", BitVecSort256, BitVecSort256, BitVecSort256)
@@ -1855,16 +1850,35 @@ class SEVM:
                 # check if there is a known matching signature
                 matching_key = None
                 for (_key, _digest), (_v, _r, _s) in ex.known_sigs.items():
-                    if eq(digest, _digest) and eq(v, _v) and eq(r, _r) and eq(s, _s):
-                        matching_key = _key
-                        break
+                    _ecrecover = f_ecrecover(_digest, _v, _r, _s)
 
-                # check if there is a known addresses associated to the matching key
+                    # check if digests and signatures don't match, then output != _addr
+                    digests_match = digest == _digest
+                    sigs_match = Or(
+                        And(v == _v, r == _r, s == _s),
+                        And(_v == v ^ 1, r == _r, s == _s - secp256k1n),
+                    )
+
+                    ex.path.append(
+                        Implies(
+                            Or(
+                                And(digests_match, Not(sigs_match)),
+                                And(Not(digests_match), sigs_match),
+                            ),
+                            output != _ecrecover,
+                        )
+                    )
+
+                    if not eq(digest, _digest):
+                        continue
+
+                    if eq(v, _v) and eq(r, _r) and eq(s, _s):
+                        matching_key = _key
+
+                # check if there is a known address associated to the matching key
                 if matching_key is not None:
                     for _key, _addr in ex.known_keys.items():
-                        if eq(matching_key, _key):
-                            ex.path.append(output == _addr)
-                            break
+                        ex.path.append((matching_key == _key) == (output == _addr))
 
                 ret = uint256(output)
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -768,6 +768,8 @@ class Exec:  # an execution path
     storages: Dict[Any, Any]  # storage updates
     balances: Dict[Any, Any]  # balance updates
     calls: List[Any]  # external calls
+    known_keys: Dict[Any, Any]  # maps address to private key
+    known_sigs: Dict[Any, Any]  # maps (private_key, digest) to (v, r, s)
 
     def __init__(self, **kwargs) -> None:
         self.code = kwargs["code"]
@@ -796,6 +798,8 @@ class Exec:  # an execution path
         self.storages = kwargs["storages"]
         self.balances = kwargs["balances"]
         self.calls = kwargs["calls"]
+        self.known_keys = kwargs["known_keys"] if "known_keys" in kwargs else {}
+        self.known_sigs = kwargs["known_sigs"] if "known_sigs" in kwargs else {}
 
         assert_address(self.context.message.target)
         assert_address(self.context.message.caller)
@@ -1769,6 +1773,8 @@ class SEVM:
                 storages=ex.storages,
                 balances=ex.balances,
                 calls=ex.calls,
+                known_keys=ex.known_keys,
+                known_sigs=ex.known_sigs,
             )
 
             stack.append((sub_ex, step_id))
@@ -2061,6 +2067,8 @@ class SEVM:
             storages=ex.storages,
             balances=ex.balances,
             calls=ex.calls,
+            known_keys=ex.known_keys,
+            known_sigs=ex.known_sigs,
         )
 
         stack.append((sub_ex, step_id))
@@ -2183,6 +2191,8 @@ class SEVM:
             storages=ex.storages.copy(),
             balances=ex.balances.copy(),
             calls=ex.calls.copy(),
+            known_keys=ex.known_keys,  # pass by reference, not need to copy
+            known_sigs=ex.known_sigs,  # pass by reference, not need to copy
         )
         return new_ex
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1828,6 +1828,9 @@ class SEVM:
             if eq(to, con_addr(1)):
                 ex.path.append(exit_code_var != con(0))
 
+                # TODO: explicitly return 32 bytes of data
+                # TODO: must tie the returned address to the input data
+
             # identity
             if eq(to, con_addr(4)):
                 ex.path.append(exit_code_var != con(0))

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1845,42 +1845,7 @@ class SEVM:
                 r = extract_bytes(arg, 64, 32)
                 s = extract_bytes(arg, 96, 32)
 
-                output = f_ecrecover(digest, v, r, s)
-
-                # check if there is a known matching signature
-                matching_key = None
-                for (_key, _digest), (_v, _r, _s) in ex.known_sigs.items():
-                    _ecrecover = f_ecrecover(_digest, _v, _r, _s)
-
-                    # check if digests and signatures don't match, then output != _addr
-                    digests_match = digest == _digest
-                    sigs_match = Or(
-                        And(v == _v, r == _r, s == _s),
-                        And(_v == v ^ 1, r == _r, s == _s - secp256k1n),
-                    )
-
-                    ex.path.append(
-                        Implies(
-                            Or(
-                                And(digests_match, Not(sigs_match)),
-                                And(Not(digests_match), sigs_match),
-                            ),
-                            output != _ecrecover,
-                        )
-                    )
-
-                    if not eq(digest, _digest):
-                        continue
-
-                    if eq(v, _v) and eq(r, _r) and eq(s, _s):
-                        matching_key = _key
-
-                # check if there is a known address associated to the matching key
-                if matching_key is not None:
-                    for _key, _addr in ex.known_keys.items():
-                        ex.path.append((matching_key == _key) == (output == _addr))
-
-                ret = uint256(output)
+                ret = uint256(f_ecrecover(digest, v, r, s))
 
             # identity
             elif eq(to, con_addr(4)):

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -141,6 +141,10 @@ def is_zero(x: Word) -> Word:
     return test(x, False)
 
 
+def is_concrete(x: Any) -> bool:
+    return isinstance(x, int) or isinstance(x, bytes) or is_bv_value(x)
+
+
 def create_solver(logic="QF_AUFBV", ctx=None, timeout=0, max_memory=0):
     # QF_AUFBV: quantifier-free bitvector + array theory: https://smtlib.cs.uiowa.edu/logics.shtml
     solver = SolverFor(logic, ctx=ctx)
@@ -175,7 +179,7 @@ def extract_bytes_argument(calldata: BitVecRef, arg_idx: int) -> bytes:
 def extract_string_argument(calldata: BitVecRef, arg_idx: int):
     """Extracts idx-th argument of string from calldata"""
     string_bytes = extract_bytes_argument(calldata, arg_idx)
-    return string_bytes.decode("utf-8") if string_bytes else ""
+    return string_bytes.decode("utf-8") if is_concrete(string_bytes) else string_bytes
 
 
 def extract_bytes(data: BitVecRef, byte_offset: int, size_bytes: int) -> BitVecRef:

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -92,6 +92,16 @@ def uint160(x: BitVecRef) -> BitVecRef:
         return simplify(ZeroExt(160 - bitsize, x))
 
 
+def uint8(x: BitVecRef) -> BitVecRef:
+    bitsize = x.size()
+    if bitsize == 8:
+        return x
+    if bitsize > 8:
+        return simplify(Extract(7, 0, x))
+    else:
+        return simplify(ZeroExt(8 - bitsize, x))
+
+
 def con(n: int, size_bits=256) -> Word:
     return BitVecVal(n, BitVecSorts[size_bits])
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -9,6 +9,10 @@ from z3 import *
 
 from .exceptions import NotConcreteError, HalmosException
 
+# order of the secp256k1 curve
+secp256k1n = (
+    115792089237316195423570985008687907852837564279074904382605163141518161494337
+)
 
 Word = Any  # z3 expression (including constants)
 Byte = Any  # z3 expression (including constants)
@@ -53,6 +57,12 @@ BitVecSort160 = BitVecSorts[160]
 BitVecSort256 = BitVecSorts[256]
 BitVecSort264 = BitVecSorts[264]
 BitVecSort512 = BitVecSorts[512]
+
+
+# ecrecover(digest, v, r, s)
+f_ecrecover = Function(
+    "ecrecover", BitVecSort256, BitVecSort8, BitVecSort256, BitVecSort256, BitVecSort160
+)
 
 
 def concat(args):

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1469,6 +1469,24 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_ecrecover_distinctKeysSameDigestCorrectRecovery(uint256,uint256,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_ecrecover_distinctKeysSameDigestDistinctAddrs(uint256,uint256,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_ecrecover_explicitMalleability(uint256,bytes32)",
                 "exitcode": 0,
                 "num_models": 0,
@@ -1478,7 +1496,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_ecrecover_samePrivateKeyCanSignMultipleDigests_with_vmaddr(uint256,bytes32,bytes32)",
+                "name": "check_ecrecover_sameKeyDistinctDigestsCorrectRecovery(uint256,bytes32,bytes32)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1487,7 +1505,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_ecrecover_samePrivateKeyCanSignMultipleDigests_without_vmaddr(uint256,bytes32,bytes32)",
+                "name": "check_ecrecover_sameKeyDistinctDigestsUniqueRecovery(uint256,bytes32,bytes32)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1498,7 +1516,7 @@
             {
                 "name": "check_ecrecover_solveForMalleability(uint256,bytes32)",
                 "exitcode": 1,
-                "num_models": 1,
+                "num_models": 3,
                 "models": null,
                 "num_paths": null,
                 "time": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1496,6 +1496,33 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_vmaddr_canFindKeyForAddr_concrete(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmaddr_canFindKeyForAddr_mixed(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmaddr_canFindKeyForAddr_symbolic(uint256,uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_vmaddr_consistent(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
@@ -1505,7 +1532,52 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_vmaddr_noCollision(uint256,uint256)",
+                "name": "check_vmaddr_noCollision_concrete(uint256,uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmaddr_noCollision_symbolic(uint256,uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmsign_canFindKeyForGivenSig(uint256,uint256,bytes32)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmsign_consistent(uint256,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmsign_noDigestCollision(uint256,bytes32,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmsign_noKeyCollision(uint256,uint256,bytes32)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1541,6 +1541,60 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_makeAddrAndKey_consistent_concrete()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_makeAddrAndKey_consistent_symbolic()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_makeAddrAndKey_noCollision_concrete()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_makeAddrAndKey_noCollision_symbolic()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_makeAddrAndKey_vmsign_ecrecover_e2e_concrete()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_makeAddrAndKey_vmsign_ecrecover_e2e_symbolic(string,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_tryRecover(address,bytes32,bytes)",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1494,6 +1494,24 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmaddr_consistent(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmaddr_noCollision(uint256,uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/SmolWETH.t.sol:SmolWETHTest": [

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1568,6 +1568,24 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_vmsign_ecrecover_e2e_recoveredCanNotMatchOtherAddr(uint256,bytes32,address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_vmsign_ecrecover_e2e_recoveredMatches(uint256,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_vmsign_noDigestCollision(uint256,bytes32,bytes32)",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1469,6 +1469,42 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_ecrecover_explicitMalleability(uint256,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_ecrecover_samePrivateKeyCanSignMultipleDigests_with_vmaddr(uint256,bytes32,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_ecrecover_samePrivateKeyCanSignMultipleDigests_without_vmaddr(uint256,bytes32,bytes32)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_ecrecover_solveForMalleability(uint256,bytes32)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_isValidERC1271SignatureNow(bytes32,bytes)",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/regression/test/Signature.t.sol
+++ b/tests/regression/test/Signature.t.sol
@@ -149,8 +149,9 @@ contract SignatureTest is SymTest, Test {
         (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(privateKey, digest1);
         (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(privateKey, digest2);
 
-        assertNotEq(r1, r2);
-        assertNotEq(s1, s2);
+        bytes memory sig1 = abi.encodePacked(v1, r1, s1);
+        bytes memory sig2 = abi.encodePacked(v2, r2, s2);
+        assertNotEq(keccak256(sig1), keccak256(sig2));
     }
 
     function check_vmsign_noKeyCollision(
@@ -163,8 +164,7 @@ contract SignatureTest is SymTest, Test {
         (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(privateKey1, digest);
         (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(privateKey2, digest);
 
-        assertNotEq(r1, r2);
-        assertNotEq(s1, s2);
+        assert(v1 != v2 || r1 != r2 || s1 != s2);
     }
 
     /// we expect a counterexample for this test

--- a/tests/regression/test/Signature.t.sol
+++ b/tests/regression/test/Signature.t.sol
@@ -177,4 +177,27 @@ contract SignatureTest is SymTest, Test {
 
         assertNotEq(r1, r2);
     }
+
+    function check_vmsign_ecrecover_e2e_recoveredMatches(
+        uint256 privateKey,
+        bytes32 digest
+    ) public {
+        address originalAddr = vm.addr(privateKey);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        address recoveredAddr = ecrecover(digest, v, r, s);
+        assertEq(originalAddr, recoveredAddr);
+    }
+
+    function check_vmsign_ecrecover_e2e_recoveredCanNotMatchOtherAddr(
+        uint256 privateKey,
+        bytes32 digest,
+        address otherAddr
+    ) public {
+        address originalAddr = vm.addr(privateKey);
+        vm.assume(originalAddr != otherAddr);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        address recoveredAddr = ecrecover(digest, v, r, s);
+        assertNotEq(otherAddr, recoveredAddr);
+    }
 }

--- a/tests/regression/test/Signature.t.sol
+++ b/tests/regression/test/Signature.t.sol
@@ -23,6 +23,8 @@ contract SymAccount is SymTest {
 }
 
 contract SignatureTest is SymTest, Test {
+    uint256 constant private ECRECOVER_PRECOMPILE = 1;
+
     function check_isValidSignatureNow(bytes32 hash, bytes memory signature) public {
         address signer = address(new SymAccount());
         if (!SignatureChecker.isValidSignatureNow(signer, hash, signature)) revert();
@@ -50,5 +52,24 @@ contract SignatureTest is SymTest, Test {
         address signer = ecrecover(hash, v, r, s);
         if (signer == address(0)) revert();
         assert(true);
+    }
+
+    function check_vmaddr_consistent(uint256 privateKey) public {
+        address addr1 = vm.addr(privateKey);
+        address addr1Bis = vm.addr(privateKey);
+
+        assertEq(addr1, addr1Bis);
+    }
+
+    function check_vmaddr_noCollision(
+        uint256 privateKey1,
+        uint256 privateKey2
+    ) public {
+        vm.assume(privateKey1 != privateKey2);
+
+        address addr1 = vm.addr(privateKey1);
+        address addr2 = vm.addr(privateKey2);
+
+        assertNotEq(addr1, addr2);
     }
 }


### PR DESCRIPTION
TODO:

- [x] support for `vm.addr`
- [x] make `vm.addr` consistent (keep track of minted addresses and reuse them)
- [x] add constraint that different keys result in different addresses
- [x] add support for `vm.label`
- [x] test that `makeAddrAndKey` is supported
- [x] add support for `vm.sign`
- [x] make `vm.sign` consistent
- [x] add constraint that different input leads to different signatures
- [x] tie `ecrecover` output to known signatures
- [ ] fix `ecrecover` implicit output size
- [x] add constraint that different hashes lead to different recovered addresses
- [x] add constraint that same hash but different signatures lead to different recovered addresses
- [x] add support for signature malleability

Open ended:

- support for concrete addresses and signatures or just purely symbolic?
- ~how do we handle signature malleability?~  (EDIT: ✅ supported)
