### PR TITLE
fix: smt encoding for evm div-by-zero

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -61,19 +61,19 @@ f_gas = Function("f_gas", BitVecSort256, BitVecSort256)
 f_gasprice = Function("f_gasprice", BitVecSort256)
 
 # uninterpreted arithmetic
-f_div = Function("f_evm_bvudiv", BitVecSort256, BitVecSort256, BitVecSort256)
+f_div = Function("f_evm_bvudiv_256", BitVecSort256, BitVecSort256, BitVecSort256)
 f_mod = {
-    256: Function("f_evm_bvurem", BitVecSort256, BitVecSort256, BitVecSort256),
+    256: Function("f_evm_bvurem_256", BitVecSort256, BitVecSort256, BitVecSort256),
     264: Function("f_evm_bvurem_264", BitVecSort264, BitVecSort264, BitVecSort264),
     512: Function("f_evm_bvurem_512", BitVecSort512, BitVecSort512, BitVecSort512),
 }
 f_mul = {
-    256: Function("f_evm_bvmul", BitVecSort256, BitVecSort256, BitVecSort256),
+    256: Function("f_evm_bvmul_256", BitVecSort256, BitVecSort256, BitVecSort256),
     512: Function("f_evm_bvmul_512", BitVecSort512, BitVecSort512, BitVecSort512),
 }
-f_sdiv = Function("f_evm_bvsdiv", BitVecSort256, BitVecSort256, BitVecSort256)
-f_smod = Function("f_evm_bvsrem", BitVecSort256, BitVecSort256, BitVecSort256)
-f_exp = Function("f_evm_exp", BitVecSort256, BitVecSort256, BitVecSort256)
+f_sdiv = Function("f_evm_bvsdiv_256", BitVecSort256, BitVecSort256, BitVecSort256)
+f_smod = Function("f_evm_bvsrem_256", BitVecSort256, BitVecSort256, BitVecSort256)
+f_exp = Function("f_evm_exp_256", BitVecSort256, BitVecSort256, BitVecSort256)
 
 magic_address: int = 0xAAAA0000
 

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -23,6 +23,24 @@
         ],
         "test/Arith.t.sol:ArithTest": [
             {
+                "name": "check_Div_fail(uint256,uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_Div_pass(uint256,uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_Exp(uint256)",
                 "exitcode": 0,
                 "num_models": 0,

--- a/tests/regression/test/Arith.t.sol
+++ b/tests/regression/test/Arith.t.sol
@@ -3,6 +3,12 @@ pragma solidity >=0.8.0 <0.9.0;
 
 contract ArithTest {
 
+    function unchecked_div(uint x, uint y) public pure returns (uint ret) {
+        assembly {
+            ret := div(x, y)
+        }
+    }
+
     function unchecked_mod(uint x, uint y) public pure returns (uint ret) {
         assembly {
             ret := mod(x, y)
@@ -33,5 +39,24 @@ contract ArithTest {
             assert(((x ** 2) ** 2) ** 2 == (x**2) * (x**2) * (x**2) * (x**2));
         //  assert(x ** 8 == (x ** 4) ** 2);
         }
+    }
+
+    function check_Div_fail(uint x, uint y) public pure {
+        require(x > y);
+
+        uint q = unchecked_div(x, y);
+
+        // note: since x > y, q can be zero only when y == 0, due to the division-by-zero semantics in the EVM
+
+        assert(q != 0); // counterexample: y == 0
+    }
+
+    function check_Div_pass(uint x, uint y) public pure {
+        require(x > y);
+        require(y > 0);
+
+        uint q = unchecked_div(x, y);
+
+        assert(q != 0); // pass
     }
 }


### PR DESCRIPTION
Fix the SMT encoding of division (and modulo) by zero.

In EVM, division (and modulo) by zero is defined to be zero, whereas they are defined differently in [SMT-LIB](https://smt-lib.org/theories-FixedSizeBitVectors.shtml).

Thus, the EVM division `(evm_bvudiv_N x y)` should be encoded as:
```
(ite (= y (_ bv0 N)) (_ bv0 N) (bvudiv x y))
```
where `N` is the bitsize. The EVM modulo operation should be encoded similarly. 