### PR TITLE
feat: --solver-command lets user replace z3 invocations

### DIFF
--- a/src/halmos/parser.py
+++ b/src/halmos/parser.py
@@ -214,20 +214,9 @@ def mk_arg_parser() -> argparse.ArgumentParser:
         help="set memory limit (in megabytes) for the solver; 0 means no limit (default: %(default)s)",
     )
     group_solver.add_argument(
-        "--solver-fresh",
-        action="store_true",
-        help="run an extra solver with a fresh state for unknown",
-    )
-    group_solver.add_argument(
-        "--solver-subprocess",
-        action="store_true",
-        help="run an extra solver in subprocess for unknown",
-    )
-    group_solver.add_argument(
-        "--solver-subprocess-command",
+        "--solver-command",
         metavar="COMMAND",
-        default="z3 -model",
-        help="use the given command for the subprocess solver (requires --solver-subprocess) (default: '%(default)s')",
+        help="use the given command when invoking the solver, e.g. `z3 -model`",
     )
     group_solver.add_argument(
         "--solver-parallel",


### PR DESCRIPTION
This removes:

- `--solver-subprocess`
- `--solver-subprocess-command`
- `--solver-fresh` (was unused AFAICT)

This adds:

- `--solver-command` with no default (meaning we run z3 in-process)
- some prints about where SMT files are generated
- auto-dumping of SMT files when invoking an external solver
- a very crude way to determine if the external solver generated a valid model (instead of assuming it is valid, so that we still benefit from refinement)

Before:

```sh
$ halmos --root examples/simple --contract VaultTest --function check_mint -vvv --statistics
[...]
[FAIL] check_mint(uint256) (paths: 8, time: 282.15s (paths: 0.45s, models: 281.70s), bounds: [])
```

After:

```sh
$ halmos --root examples/simple --contract VaultTest --function check_mint -vvv --statistics --solver-command="bitwuzla -m"
[...]
[FAIL] check_mint(uint256) (paths: 8, time: 19.69s (paths: 0.46s, models: 19.22s), bounds: [])
```