### PR TITLE
dep: unpin z3 version (cont'd)

### DIFF
--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -39,7 +39,9 @@ jobs:
           python -m pip install pytest
 
       - name: Install Halmos
-        run: python -m pip install -e .
+        run: |
+          python -m pip install z3-solver==4.12.2.0
+          python -m pip install -e .
 
       - name: Run pytest
         run: pytest -x -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options="-v -st --solver-timeout-assertion 0 --solver-threads 2" -s --log-cli-level=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "z3-solver==4.12.2.0",
+    "z3-solver>=4.13",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "z3-solver>=4.13",
+    "z3-solver",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-z3-solver>=4.13
+z3-solver


### PR DESCRIPTION
unpin z3 version, with no minimum version requirement

for future reference:
- #235 pinned z3 to 4.12.2 because at that time, pip install z3 4.12.3 didn't utilize the installation cache (it cached the package download but not the installation).
- it seems that the issue has been fixed in a later z3 version, and #275 attempted to unpin z3 and require the version >= 4.13 (the latest version)
- however, since version 4.13 turned out to [significantly underperforms](https://github.com/a16z/halmos/actions/runs/8728205393) for nonlinear queries, even with int-blasting enabled, this pr removes the minimum version requirement, and specifies a particular version for long-running ci tests.