### PR TITLE
chore: remove requirements.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,18 +23,20 @@ git clone git@github.com:a16z/halmos.git
 Create and activate a virtual environment:
 
 ```sh
-python3.11 -m venv .venv
-source .venv/bin/activate
+python3.12 -m venv .venv && source .venv/bin/activate
 ```
 
 Install the dependencies:
 
 ```sh
-python -m pip install -r requirements.txt
+# install halmos and its runtime dependencies
+python -m pip install -e .
+
+# install the dev dependencies
 python -m pip install -r requirements-dev.txt
 ```
 
-Install and run the git hook scripts:
+Install and run the git hook scripts (this is optional but will make sure that your PR will follow the style convention):
 
 ```sh
 pre-commit install
@@ -46,7 +48,7 @@ pre-commit run --all-files
 We recommend enabling the [black] formatter in your editor, but you can run it manually if needed:
 
 ```sh
-python -m black .
+python -m black src/
 ```
 
 [black]: <https://black.readthedocs.io/en/stable/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2", "black"]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 black
 pre-commit
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-z3-solver


### PR DESCRIPTION
Let's standardize on:

- pyproject.toml for halmos and its runtime dependencies (for users + devs)
- requirements-dev.txt for the dev dependencies (for devs only)