### PR TITLE
fix: use --ast to enable foundry build cache

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1406,7 +1406,7 @@ def _main(_args=None) -> MainResult:
     build_cmd = [
         "forge",  # shutil.which('forge')
         "build",
-        "--build-info",
+        "--ast",
         "--root",
         args.root,
         "--extra-output",


### PR DESCRIPTION
fix #285

simply use --ast instead of --build-info, and require users to foundryup, as suggested in https://github.com/a16z/halmos/issues/285#issuecomment-2098864373:

> Maybe as a workaround we can use --ast. If we're going to do that:
> 
> - either we check the forge version first, and then only add the --ast flag if it's in a supported foundry version
> - or it will fail and we require the users to foundryup