### PR TITLE
run workflow using `solvers` as a base image

### DIFF
--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Install Git
-        run: sudo apt-get install -y git
+        run: apt-get install -y git
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build image
         run: |
           docker build -t halmos . --file packages/halmos/Dockerfile

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Install Git
-        run: apt-get install -y git
+        run: apt-get update && apt-get install -y git
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/a16z/solvers
 
     strategy:
       fail-fast: false
@@ -20,24 +19,15 @@ jobs:
           - testname: "examples/tokens/ERC721"
 
     steps:
-      - name: Install Git
-        run: apt-get update && apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.12'
-
-      - name: Install halmos and dev dependencies
+      - name: Build image
         run: |
-          python3 -m pip install -e .
-          python3 -m pip install -r requirements-dev.txt
+          docker build -t halmos . --file packages/halmos/Dockerfile
 
       - name: Run Pytest
         run: |
-          pytest -x -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options='-v -st --solver-timeout-assertion 0 --solver-threads 6 --solver-command=yices-smt2' -s --log-cli-level=
+          docker run -v .:/workspace --entrypoint pytest halmos -x -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options='-v -st --solver-timeout-assertion 0 --solver-threads 6 --solver-command=yices-smt2' -s --log-cli-level=

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -20,14 +20,23 @@ jobs:
           - testname: "examples/tokens/ERC721"
 
     steps:
+      - name: Install Git
+        run: sudo apt-get install -y git
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install halmos
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.12'
+
+      - name: Install halmos and dev dependencies
         run: |
           python3 -m pip install -e .
+          python3 -m pip install -r requirements-dev.txt
 
       - name: Run Pytest
         run: |

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/emperororokusaki/solvers:0.1.0
+    container: ghcr.io/a16z/solvers
 
     strategy:
       fail-fast: false

--- a/packages/halmos/Dockerfile
+++ b/packages/halmos/Dockerfile
@@ -1,0 +1,34 @@
+FROM ghcr.io/a16z/solvers:latest
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git \
+    python3 \
+    python3-pip \
+    wget \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Foundry
+COPY --from=ghcr.io/foundry-rs/foundry:latest \
+    /usr/local/bin/forge \
+    /usr/local/bin/cast \
+    /usr/local/bin/
+
+# Install uv
+ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+RUN /install.sh && rm /install.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Enable the virtual environment
+ENV PATH="/halmos/.venv/bin:$PATH"
+ENV VIRTUAL_ENV='/halmos/.venv'
+
+# Install halmos, assuming it is checked out in the context directory
+WORKDIR /halmos
+RUN --mount=type=bind,source=../..,target=/src,readonly=false \
+    uv venv && \
+    uv pip install --no-cache /src && \
+    uv pip install --no-cache -r /src/requirements-dev.txt
+
+WORKDIR /workspace
+ENTRYPOINT ["halmos"]

--- a/packages/halmos/README.md
+++ b/packages/halmos/README.md
@@ -1,0 +1,15 @@
+# halmos Docker image
+
+```sh
+# build it
+docker build -t halmos --file packages/halmos/Dockerfile .
+
+# run it
+docker run --rm -v .:/workspace halmos --root tests/regression --function check_log_string
+
+# run the container interactively (for debugging)
+docker run --rm -v .:/workspace -it --entrypoint bash halmos
+
+# run tests
+docker run -v .:/workspace --entrypoint pytest halmos -k test_config.py
+```


### PR DESCRIPTION
Example run: 
https://github.com/a16z/halmos/actions/runs/9409762438

This works at least as a proof of concept. We should be able to optimize the 1min "build image step" a little bit more:
- since we want to keep the solvers package very minimal, we need to add the other dependencies we need in CI for halmos (git, python, foundry, etc)
- we need to checkout the current halmos from github and install it

It would be faster to use either an already published `halmos:latest` image (but wouldn't help for running tests on a branch). 

Alternatively we could also publish an intermediary `halmos-base` image that already includes git, python, foundry, uv, etc. and we would only need to install the halmos checkout.