### PR TITLE
[Feature/#244] Parse symbols from build to print readable traces

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -303,7 +303,7 @@ def render_trace(context: CallContext, file=sys.stdout) -> None:
                 bytecode = context.output.data.unwrap().hex()
                 contract_name = (
                     Mapper()
-                    .get_contarct_mapping_info_by_bytecode(bytecode)
+                    .get_contract_mapping_info_by_bytecode(bytecode)
                     .contract_name
                 )
 

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -284,6 +284,7 @@ def render_trace(context: CallContext, file=sys.stdout) -> None:
     message = context.message
     addr = unbox_int(message.target)
     addr_str = str(addr) if is_bv(addr) else hex(addr)
+    # check if we have a contract name for this address in our deployment mapper
     addr_str = DeployAddressMapper().get_deployed_contract(addr_str)
 
     value = unbox_int(message.value)

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -126,3 +126,15 @@ class Mapper(metaclass=SingletonMeta):
             if node["nodeType"] == "ContractDefinition"
             else contract_name
         )
+
+    def find_nodes_by_address(self, address: str):
+        result = ""
+        for contract_name, contract_info in self._contracts.items():
+            matching_nodes = [
+                node for node in contract_info.nodes if node.address == address
+            ]
+
+            for node in matching_nodes:
+                result += f"{contract_name}.{node.name} "
+
+        return result.strip() if result != "" and address != "0x" else address

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -58,6 +58,14 @@ class Mapper(metaclass=SingletonMeta):
     def get_contract_mapping_info_by_bytecode(
         self, bytecode: str
     ) -> Optional[ContractMappingInfo]:
+        # TODO: Handle cases for contracts with immutable variables
+        # Current implementation might not work correctly if the following code is added the test solidity file
+        #
+        # address immutable public owner;
+        # constructor() {
+        #     owner = msg.sender;
+        # }
+
         for contract_mapping_info in self._contracts.values():
             if contract_mapping_info.bytecode.endswith(bytecode):
                 return contract_mapping_info

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Type
+
+
+@dataclass
+class AstNode:
+    node_type: str
+    id: int
+    name: str
+    address: str
+    visibility: str
+
+
+@dataclass
+class ContractMappingInfo:
+    contract_name: str
+    bytecode: str
+    nodes: List[AstNode]
+
+
+class SingletonMeta(type):
+    _instances: Dict[Type, Any] = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+
+        return cls._instances[cls]
+
+
+class Mapper(metaclass=SingletonMeta):
+    def __init__(self):
+        self._contracts: Dict[str, ContractMappingInfo] = {}
+
+    def add_contract_mapping_info(
+        self, contract_name: str, bytecode: str, nodes: List[AstNode] = []
+    ):
+        if contract_name in self._contracts:
+            raise ValueError(f"Contract {contract_name} already exists")
+
+        self._contracts[contract_name] = ContractMappingInfo(
+            contract_name, bytecode, nodes
+        )
+
+    def get_contract_mapping_info_by_name(
+        self, contract_name: str
+    ) -> Optional[ContractMappingInfo]:
+        return self._contracts.get(contract_name, None)
+
+    def get_contarct_mapping_info_by_bytecode(
+        self, bytecode: str
+    ) -> Optional[ContractMappingInfo]:
+        for contract_mapping_info in self._contracts.values():
+            if contract_mapping_info.bytecode == bytecode:
+                return contract_mapping_info
+
+        return None
+
+    def append_node(self, contract_name: str, node: AstNode):
+        contract_mapping_info = self.get_contract_mapping_info_by_name(contract_name)
+
+        if contract_mapping_info is None:
+            raise ValueError(f"Contract {contract_name} not found")
+
+        contract_mapping_info.nodes.append(node)

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -29,11 +29,19 @@ class SingletonMeta(type):
 
 
 class Mapper(metaclass=SingletonMeta):
+    _PARSING_IGNORED_NODE_TYPES = [
+        "StructDefinition",
+        "EnumDefinition",
+        "PragmaDirective",
+        "ImportDirective",
+        "Block",
+    ]
+
     def __init__(self):
         self._contracts: Dict[str, ContractMappingInfo] = {}
 
     def add_contract_mapping_info(
-        self, contract_name: str, bytecode: str, nodes: List[AstNode] = []
+        self, contract_name: str, bytecode: str, nodes: List[AstNode]
     ):
         if contract_name in self._contracts:
             raise ValueError(f"Contract {contract_name} already exists")
@@ -63,3 +71,58 @@ class Mapper(metaclass=SingletonMeta):
             raise ValueError(f"Contract {contract_name} not found")
 
         contract_mapping_info.nodes.append(node)
+
+    def parse_ast(self, node: Dict, contract_name: str = ""):
+        node_type = node["nodeType"]
+
+        if node_type in self._PARSING_IGNORED_NODE_TYPES:
+            return
+
+        current_contract = self._get_current_contract(node, contract_name)
+
+        if node_type == "ContractDefinition":
+            if current_contract not in self._contracts:
+                self.add_contract_mapping_info(
+                    contract_name=current_contract, bytecode="", nodes=[]
+                )
+
+            if self.get_contract_mapping_info_by_name(current_contract).nodes:
+                return
+        elif node_type != "SourceUnit":
+            id, name, address, visibility = self._get_node_info(node, node_type)
+
+            self.append_node(
+                current_contract,
+                AstNode(node_type, id, name, address, visibility),
+            )
+
+        for child_node in node.get("nodes", []):
+            self.parse_ast(child_node, current_contract)
+
+        if "body" in node:
+            self.parse_ast(node["body"], current_contract)
+
+    def _get_node_info(self, node: Dict, node_type: str) -> Dict:
+        return (
+            node.get("id", ""),
+            node.get("name", ""),
+            self._get_node_address(node, node_type),
+            node.get("visibility", ""),
+        )
+
+    def _get_node_address(self, node: Dict, node_type: str) -> str:
+        address_fields = {
+            "VariableDeclaration": "functionSelector",
+            "FunctionDefinition": "functionSelector",
+            "EventDefinition": "eventSelector",
+            "ErrorDefinition": "errorSelector",
+        }
+
+        return node.get(address_fields.get(node_type, ""), "")
+
+    def _get_current_contract(self, node: Dict, contract_name: str) -> str:
+        return (
+            node.get("name", "")
+            if node["nodeType"] == "ContractDefinition"
+            else contract_name
+        )

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -55,7 +55,7 @@ class Mapper(metaclass=SingletonMeta):
     ) -> Optional[ContractMappingInfo]:
         return self._contracts.get(contract_name, None)
 
-    def get_contarct_mapping_info_by_bytecode(
+    def get_contract_mapping_info_by_bytecode(
         self, bytecode: str
     ) -> Optional[ContractMappingInfo]:
         for contract_mapping_info in self._contracts.values():

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -106,7 +106,7 @@ class Mapper(metaclass=SingletonMeta):
         return (
             node.get("id", ""),
             node.get("name", ""),
-            self._get_node_address(node, node_type),
+            "0x" + self._get_node_address(node, node_type),
             node.get("visibility", ""),
         )
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import re
+from functools import partial
 from timeit import default_timer as timer
 from typing import Any, Dict, Optional, Tuple
 from typing import Union as UnionType
@@ -315,23 +316,25 @@ def decode_hex(hexstring: str) -> Optional[bytes]:
         return None
 
 
-def hexify(x):
+def hexify(x, contract_name: str = None):
     if isinstance(x, str):
         return re.sub(r"\b(\d+)\b", lambda match: hex(int(match.group(1))), x)
     elif isinstance(x, int):
         return f"0x{x:02x}"
     elif isinstance(x, bytes):
-        return Mapper().find_nodes_by_address("0x" + x.hex())
+        return Mapper().find_nodes_by_address("0x" + x.hex(), contract_name)
     elif hasattr(x, "unwrap"):
-        return hexify(x.unwrap())
+        return hexify(x.unwrap(), contract_name)
     elif is_bv_value(x):
         # maintain the byte size of x
         num_bytes = byte_length(x, strict=False)
-        return Mapper().find_nodes_by_address(f"0x{x.as_long():0{num_bytes * 2}x}")
+        return Mapper().find_nodes_by_address(
+            f"0x{x.as_long():0{num_bytes * 2}x}", contract_name
+        )
     elif is_app(x):
-        return f"{str(x.decl())}({', '.join(map(hexify, x.children()))})"
+        return f"{str(x.decl())}({', '.join(map(partial(hexify, contract_name=contract_name), x.children()))})"
     else:
-        return hexify(str(x))
+        return hexify(str(x), contract_name)
 
 
 def render_uint(x: BitVecRef) -> str:

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import re
-
 from timeit import default_timer as timer
-from typing import Dict, Tuple, Any, Optional, Union as UnionType
+from typing import Any, Dict, Optional, Tuple
+from typing import Union as UnionType
 
 from z3 import *
 
-from .exceptions import NotConcreteError, HalmosException
+from halmos.mapper import Mapper
+
+from .exceptions import HalmosException, NotConcreteError
 
 # order of the secp256k1 curve
 secp256k1n = (
@@ -319,13 +321,13 @@ def hexify(x):
     elif isinstance(x, int):
         return f"0x{x:02x}"
     elif isinstance(x, bytes):
-        return "0x" + x.hex()
+        return Mapper().find_nodes_by_address("0x" + x.hex())
     elif hasattr(x, "unwrap"):
         return hexify(x.unwrap())
     elif is_bv_value(x):
         # maintain the byte size of x
         num_bytes = byte_length(x, strict=False)
-        return f"0x{x.as_long():0{num_bytes * 2}x}"
+        return Mapper().find_nodes_by_address(f"0x{x.as_long():0{num_bytes * 2}x}")
     elif is_app(x):
         return f"{str(x.decl())}({', '.join(map(hexify, x.children()))})"
     else:

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -69,7 +69,7 @@ def test_get_contract_mapping_info_by_bytecode(mapper, ast_nodes):
 
 
 def test_get_contract_mapping_info_by_bytecode_nonexistent(mapper):
-    contract_info = mapper.get_contarct_mapping_info_by_bytecode("bytecodeA")
+    contract_info = mapper.get_contract_mapping_info_by_bytecode("bytecodeA")
     assert contract_info is None
 
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,0 +1,93 @@
+from typing import List
+
+import pytest
+
+from halmos.mapper import AstNode, ContractMappingInfo, Mapper, SingletonMeta
+
+
+@pytest.fixture
+def ast_nodes() -> List[AstNode]:
+    return [
+        AstNode(
+            node_type="type1", id=1, name="Node1", address="0x123", visibility="public"
+        ),
+        AstNode(
+            node_type="type2", id=2, name="Node2", address="0x456", visibility="private"
+        ),
+    ]
+
+
+@pytest.fixture
+def mapper() -> Mapper:
+    return Mapper()
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    SingletonMeta._instances = {}
+
+
+def test_singleton():
+    mapper1 = Mapper()
+    mapper2 = Mapper()
+    assert mapper1 is mapper2
+
+
+def test_add_contract_mapping_info(mapper, ast_nodes):
+    mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
+    contract_info = mapper.get_contract_mapping_info_by_name("ContractA")
+    assert contract_info is not None
+    assert contract_info.contract_name == "ContractA"
+    assert contract_info.bytecode == "bytecodeA"
+    assert len(contract_info.nodes) == 2
+
+
+def test_add_contract_mapping_info_already_existence(mapper, ast_nodes):
+    mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
+
+    with pytest.raises(ValueError, match=r"Contract ContractA already exists"):
+        mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
+
+
+def test_get_contract_mapping_info_by_name(mapper, ast_nodes):
+    mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
+    contract_info = mapper.get_contract_mapping_info_by_name("ContractA")
+    assert contract_info is not None
+    assert contract_info.contract_name == "ContractA"
+
+
+def test_get_contract_mapping_info_by_name_nonexistent(mapper):
+    contract_info = mapper.get_contract_mapping_info_by_name("ContractA")
+    assert contract_info is None
+
+
+def test_get_contract_mapping_info_by_bytecode(mapper, ast_nodes):
+    mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
+    contract_info = mapper.get_contarct_mapping_info_by_bytecode("bytecodeA")
+    assert contract_info is not None
+    assert contract_info.bytecode == "bytecodeA"
+
+
+def test_get_contract_mapping_info_by_bytecode_nonexistent(mapper):
+    contract_info = mapper.get_contarct_mapping_info_by_bytecode("bytecodeA")
+    assert contract_info is None
+
+
+def test_append_node(mapper, ast_nodes):
+    mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
+    new_node = AstNode(
+        node_type="type3", id=3, name="Node3", address="0x789", visibility="public"
+    )
+    mapper.append_node("ContractA", new_node)
+    contract_info = mapper.get_contract_mapping_info_by_name("ContractA")
+    assert contract_info is not None
+    assert len(contract_info.nodes) == 3
+    assert contract_info.nodes[-1].id == 3
+
+
+def test_append_node_to_nonexistent_contract(mapper):
+    new_node = AstNode(
+        node_type="type3", id=3, name="Node3", address="0x789", visibility="public"
+    )
+    with pytest.raises(ValueError, match=r"Contract NonexistentContract not found"):
+        mapper.append_node("NonexistentContract", new_node)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -91,3 +91,86 @@ def test_append_node_to_nonexistent_contract(mapper):
     )
     with pytest.raises(ValueError, match=r"Contract NonexistentContract not found"):
         mapper.append_node("NonexistentContract", new_node)
+
+
+def test_parse_simple_ast(mapper):
+    example_ast = {
+        "nodeType": "ContractDefinition",
+        "id": 1,
+        "name": "ExampleContract",
+        "nodes": [
+            {
+                "nodeType": "FunctionDefinition",
+                "id": 2,
+                "name": "exampleFunction",
+                "functionSelector": "abcdef",
+                "visibility": "public",
+                "nodes": [],
+            }
+        ],
+    }
+    mapper.parse_ast(example_ast)
+    contract_info = mapper.get_contract_mapping_info_by_name("ExampleContract")
+
+    assert contract_info is not None
+    assert contract_info.contract_name == "ExampleContract"
+    assert len(contract_info.nodes) == 1
+    assert contract_info.nodes[0].name == "exampleFunction"
+
+
+def test_parse_complex_ast(mapper):
+    complex_ast = {
+        "nodeType": "ContractDefinition",
+        "id": 1,
+        "name": "ComplexContract",
+        "nodes": [
+            {
+                "nodeType": "VariableDeclaration",
+                "id": 2,
+                "name": "var1",
+                "functionSelector": "",
+                "visibility": "private",
+            },
+            {
+                "nodeType": "FunctionDefinition",
+                "id": 3,
+                "name": "func1",
+                "functionSelector": "222222",
+                "visibility": "public",
+                "nodes": [
+                    {
+                        "nodeType": "Block",
+                        "id": 4,
+                        "name": "innerBlock",
+                        "functionSelector": "",
+                        "visibility": "",
+                    }
+                ],
+            },
+            {
+                "nodeType": "EventDefinition",
+                "id": 5,
+                "name": "event1",
+                "eventSelector": "444444",
+                "visibility": "public",
+            },
+            {
+                "nodeType": "ErrorDefinition",
+                "id": 6,
+                "name": "error1",
+                "errorSelector": "555555",
+                "visibility": "public",
+            },
+        ],
+    }
+    mapper.parse_ast(complex_ast)
+    contract_info = mapper.get_contract_mapping_info_by_name("ComplexContract")
+    assert contract_info is not None
+    assert contract_info.contract_name == "ComplexContract"
+    assert len(contract_info.nodes) == 4
+
+    node_names = [node.name for node in contract_info.nodes]
+    assert "var1" in node_names
+    assert "func1" in node_names
+    assert "event1" in node_names
+    assert "error1" in node_names

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -63,7 +63,7 @@ def test_get_contract_mapping_info_by_name_nonexistent(mapper):
 
 def test_get_contract_mapping_info_by_bytecode(mapper, ast_nodes):
     mapper.add_contract_mapping_info("ContractA", "bytecodeA", ast_nodes)
-    contract_info = mapper.get_contarct_mapping_info_by_bytecode("bytecodeA")
+    contract_info = mapper.get_contract_mapping_info_by_bytecode("bytecodeA")
     assert contract_info is not None
     assert contract_info.bytecode == "bytecodeA"
 


### PR DESCRIPTION
## Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (Not Breaking-change. Solve issue.)
- [x] New feature (Not Breaking-change. Add new feature.)
- [ ] Breaking change (Bug fix or New featrure that cause Breaking change.)
- [ ] Code Convention (Edit Code Convention.)
- [ ] Refactoring (Refactor Code without feature change.)

## Description
This PR introduces several significant updates and new functionalities that parse and covert raw hex code to human readable string. The changes primarily focus on enhancing the Mapper class with methods for AST parsing and adding the DeployAddressMapper class for managing deployed contract address mappings.

## Related Issues
This PR resolves #244 


## Changes
1. Mapper class
    * Implemented using the Singleton pattern to manage contract and node mapping information from AST
    * Use AstNode and ContractMappingInfo dataclasses
    * Methods
        * parse_ast: Recursively parses AST nodes.
        * add_contract_mapping_info: Adds a new contract mapping
        * get_contract_mapping_info_by_name: Retrieves contract mapping by contract name
        * get_contract_mapping_info_by_bytecode: Retrieves contract mapping by bytecode suffix
        * append_node: Appends a new AST node to contract mapping info
        * find_nodes_by_address: Converts hex addresses to human-readable strings including contract name, event name, function name, and variable name

2. DeployAddressMapper class
    * Implemented using the Singleton pattern
    * Added to manage deployed contract address mappings with predefined mappings such as HEVM and SVM.

3. Modify functions when used for printing traces
    * render_trace: Added logic to look up deployed contract names.
    * rendered_calldata, hexify, find_nodes_by_address: Updated to support contract name parameters for searching nodes in specific contracts.

## Tests
```
> cd halmos/examples/simple
> halmos -vvvv
```

## Screenshot
![image](https://github.com/a16z/halmos/assets/6031805/a27a3891-4296-4495-acf9-b27d253cca65)
