### PR TITLE
ci: add snekmate to external test suites

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -82,7 +82,7 @@ jobs:
         run: python -m pip install -e ./halmos
 
       - name: Install Vyper
-        if: ${{ matrix.project.dir == "snekmate" }}
+        if: ${{ matrix.project.dir == 'snekmate' }}
         run: python -m pip install vyper
 
       - name: Install Yices 2 SMT solver

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -24,22 +24,32 @@ jobs:
             dir: "morpho-data-structures"
             cmd: "halmos --function testProve --loop 4 --symbolic-storage"
             branch: ""
+            profile: ""
           - repo: "a16z/cicada"
             dir: "cicada"
             cmd: "halmos --contract LibUint1024Test --function testProve --loop 256"
             branch: ""
+            profile: ""
           - repo: "a16z/cicada"
             dir: "cicada"
             cmd: "halmos --contract LibPrimeTest --function testProve --loop 256"
             branch: ""
+            profile: ""
           - repo: "farcasterxyz/contracts"
             dir: "farcaster-contracts"
             cmd: "halmos"
             branch: ""
+            profile: ""
           - repo: "zobront/halmos-solady"
             dir: "halmos-solady"
             cmd: "halmos --function testCheck"
             branch: ""
+            profile: ""
+          - repo: "pcaversaccio/snekmate"
+            dir: "snekmate"
+            cmd: "halmos --config test/halmos.toml"
+            branch: ""
+            profile: "halmos"
 
     steps:
       - name: Checkout
@@ -57,17 +67,32 @@ jobs:
           ref: ${{ matrix.project.branch }}
           submodules: recursive
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Build image
-        run: docker build -t halmos . --file packages/halmos/Dockerfile
-        working-directory: halmos
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip
+
+      - name: Install Halmos
+        run: python -m pip install -e ./halmos
+
+      - name: Install Vyper
+        if: ${{ matrix.project.dir == "snekmate" }}
+        run: python -m pip install vyper
+
+      - name: Install Yices 2 SMT solver
+        run: |
+          sudo add-apt-repository ppa:sri-csl/formal-methods
+          sudo apt-get update
+          sudo apt-get install yices2
 
       - name: Test external repo
-        run: docker run -v .:/workspace ${{ matrix.project.cmd }} --statistics --solver-timeout-assertion 0 --solver-threads 4 --solver-command yices-smt2 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}
+        run: ${{ matrix.project.cmd }} --statistics --solver-timeout-assertion 0 --solver-threads 4 --solver-command yices-smt2 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}
         working-directory: ${{ matrix.project.dir }}
+        env:
+          FOUNDRY_PROFILE: ${{ matrix.project.profile }}


### PR DESCRIPTION
add snekmate to test-external.

note: this temporarily de-dockerizes the test-external workflow as the snekmate test requires installing vyper dependency.

as mentioned in #308, we may need to create a halmos-dev image that includes these test dependencies to dockerize test-external again.

note: snekmate test takes much longer >40m.