### PR TITLE
ci: pin yices2=2.6.4

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -87,9 +87,12 @@ jobs:
 
       - name: Install Yices 2 SMT solver
         run: |
-          sudo add-apt-repository ppa:sri-csl/formal-methods
-          sudo apt-get update
-          sudo apt-get install yices2
+          wget https://github.com/SRI-CSL/yices2/releases/download/Yices-2.6.4/yices-2.6.4-x86_64-pc-linux-gnu.tar.gz
+          tar -xzvf yices-2.6.4-x86_64-pc-linux-gnu.tar.gz
+          sudo mv yices-2.6.4/bin/* /usr/local/bin/
+          sudo mv yices-2.6.4/lib/* /usr/local/lib/
+          sudo mv yices-2.6.4/include/* /usr/local/include/
+          rm -rf yices-2.6.4
 
       - name: Test external repo
         run: ${{ matrix.project.cmd }} --statistics --solver-timeout-assertion 0 --solver-threads 4 --solver-command yices-smt2 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}


### PR DESCRIPTION
pin yices2 to version 2.6.4, to avoid the significantly different performance profile of the newer version [2.6.5](https://github.com/SRI-CSL/yices2/releases/tag/Yices-2.6.5)