### PR TITLE
perf: early exit for fail()

### DIFF
--- a/src/halmos/exceptions.py
+++ b/src/halmos/exceptions.py
@@ -8,11 +8,22 @@ Note: this is a modified version execution-specs' src/ethereum/<fork>/vm/excepti
 """
 
 
-class InfeasiblePath(Exception):
+class PathEndingException(Exception):
+    """
+    Base class for any exception that should stop the current path exploration.
+
+    Stopping path exploration means stopping not only the current EVM context but also its parent contexts if any.
+    """
+
     pass
 
 
-class HalmosException(Exception):
+class HalmosException(PathEndingException):
+    """
+    Base class for unexpected internal errors happening during a test run.
+    Inherits from RunEndingException because it should stop further path exploration.
+    """
+
     pass
 
 
@@ -20,17 +31,18 @@ class NotConcreteError(HalmosException):
     pass
 
 
-class HalmosTargetReached(Exception):
+class InfeasiblePath(PathEndingException):
     """
-    A separate exception that signals the search target has been reached, such as assertion violations.
+    Raise when the current path condition turns out to be infeasible.
     """
 
     pass
 
 
-class FailCheatcode(HalmosTargetReached):
+class FailCheatcode(PathEndingException):
     """
-    Raised when invoking hevm's vm.fail() cheatcode
+    Raised when invoking DSTest's fail() pseudo-cheatcode.
+    Inherits from RunEndingException because it should stop further path exploration.
     """
 
     pass

--- a/src/halmos/exceptions.py
+++ b/src/halmos/exceptions.py
@@ -20,6 +20,22 @@ class NotConcreteError(HalmosException):
     pass
 
 
+class HalmosTargetReached(Exception):
+    """
+    A separate exception that signals the search target has been reached, such as assertion violations.
+    """
+
+    pass
+
+
+class FailCheatcode(HalmosTargetReached):
+    """
+    Raised when invoking hevm's vm.fail() cheatcode
+    """
+
+    pass
+
+
 class EvmException(Exception):
     """
     Base class for all EVM exceptions.
@@ -131,14 +147,6 @@ class InvalidParameter(ExceptionalHalt):
 class InvalidContractPrefix(ExceptionalHalt):
     """
     Raised when the new contract code starts with 0xEF.
-    """
-
-    pass
-
-
-class FailCheatcode(ExceptionalHalt):
-    """
-    Raised when invoking hevm's vm.fail() cheatcode
     """
 
     pass

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2544,7 +2544,7 @@ class SEVM:
                 yield from finalize(ex)
                 continue
 
-            except HalmosTargetReached as err:
+            except FailCheatcode as err:
                 # return data shouldn't be None, as it is considered being stuck
                 ex.halt(data=ByteVec(), error=err)
                 yield ex  # early exit; do not call finalize()

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2128,6 +2128,9 @@ class SEVM:
             if ex.callback is None:
                 yield ex
 
+            elif isinstance(ex.context.output.error, FailCheatcode):
+                yield ex
+
             # otherwise, execute the callback to return to the parent execution context
             # note: `yield from` is used as the callback may yield the current execution state that got stuck
             else:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2128,9 +2128,6 @@ class SEVM:
             if ex.callback is None:
                 yield ex
 
-            elif isinstance(ex.context.output.error, FailCheatcode):
-                yield ex
-
             # otherwise, execute the callback to return to the parent execution context
             # note: `yield from` is used as the callback may yield the current execution state that got stuck
             else:
@@ -2545,6 +2542,12 @@ class SEVM:
 
                 ex.halt(data=None, error=err)
                 yield from finalize(ex)
+                continue
+
+            except HalmosTargetReached as err:
+                # return data shouldn't be None, as it is considered being stuck
+                ex.halt(data=ByteVec(), error=err)
+                yield ex  # early exit; do not call finalize()
                 continue
 
     def mk_exec(

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -766,6 +766,17 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/Foundry.t.sol:DeepFailer": [
+            {
+                "name": "check_fail_cheatcode()",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/Foundry.t.sol:FoundryTest": [
             {
                 "name": "check_assume(uint256)",

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -427,7 +427,7 @@
             {
                 "name": "check_call1_fail(uint256)",
                 "exitcode": 1,
-                "num_models": 2,
+                "num_models": 1,
                 "models": null,
                 "num_paths": null,
                 "time": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -777,6 +777,17 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/Foundry.t.sol:EarlyFailTest": [
+            {
+                "name": "check_early_fail_cheatcode(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/Foundry.t.sol:FoundryTest": [
             {
                 "name": "check_assume(uint256)",

--- a/tests/regression/test/Foundry.t.sol
+++ b/tests/regression/test/Foundry.t.sol
@@ -27,6 +27,8 @@ contract EarlyFailTest is Test {
     }
 
     function check_early_fail_cheatcode(uint x) public {
+        // we want `fail()` to happen in a nested context,
+        // to test that it ends not just the current context but the whole run
         address(this).call(abi.encodeWithSelector(this.do_fail.selector, ""));
 
         // this shouldn't be reached due to the early fail() semantics.

--- a/tests/regression/test/Foundry.t.sol
+++ b/tests/regression/test/Foundry.t.sol
@@ -21,6 +21,22 @@ contract DeepFailer is Test {
     }
 }
 
+contract EarlyFailTest is Test {
+    function do_fail() external {
+        fail();
+    }
+
+    function check_early_fail_cheatcode(uint x) public {
+        address(this).call(abi.encodeWithSelector(this.do_fail.selector, ""));
+
+        // this shouldn't be reached due to the early fail() semantics.
+        // if this assertion is executed, two counterexamples will be generated:
+        // - counterexample caused by fail(): x > 0
+        // - counterexample caused by assert(x > 0): x == 0
+        assert(x > 0);
+    }
+}
+
 contract FoundryTest is Test {
     /* TODO: support checkFail prefix
     function checkFail() public {

--- a/tests/regression/test/Foundry.t.sol
+++ b/tests/regression/test/Foundry.t.sol
@@ -16,7 +16,7 @@ contract DeepFailer is Test {
         }
     }
 
-    function test_fail_cheatcode() public {
+    function check_fail_cheatcode() public {
         DeepFailer(address(this)).do_test(0);
     }
 }


### PR DESCRIPTION
fix fail() to exit early.

previously, fail() was treated as a normal evm exception, allowing execution to continue after returning to the caller if any. (see the new test as example.) such continued execution is unnecessary. now fail() exits immediately, avoiding potential performance degradation.