### PR TITLE
fix bad abi encoding in createBytes4

### DIFF
--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -188,7 +188,7 @@ def create_string(ex, arg):
 
 def create_bytes4(ex, arg):
     name = name_of(extract_string_argument(arg, 0))
-    return uint256(create_generic(ex, 32, name, "bytes4"))
+    return Concat(create_generic(ex, 32, name, "bytes4"), con(0, size_bits=224))
 
 
 def create_bytes32(ex, arg):

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -931,9 +931,18 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_createBytes4()",
+                "name": "check_createBytes4_basic()",
                 "exitcode": 0,
                 "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createBytes4_finds_selector()",
+                "exitcode": 1,
+                "num_models": 1,
                 "models": null,
                 "num_paths": null,
                 "time": null,


### PR DESCRIPTION
bytes4 must be right-padded with 0s, not left padded