### PR TITLE
trace rendering: extract selector from calldata

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -277,7 +277,18 @@ def rendered_trace(context: CallContext) -> str:
 
 
 def rendered_calldata(calldata: ByteVec, contract_name: str | None = None) -> str:
-    return hexify(calldata.unwrap(), contract_name) if calldata else "0x"
+    if not calldata:
+        return "0x"
+
+    if len(calldata) < 4:
+        return hexify(calldata)
+
+    if len(calldata) == 4:
+        return f"{hexify(calldata.unwrap(), contract_name)}()"
+
+    selector = calldata[:4].unwrap()
+    args = calldata[4:].unwrap()
+    return f"{hexify(selector, contract_name)}({hexify(args)})"
 
 
 def render_trace(context: CallContext, file=sys.stdout) -> None:

--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -199,12 +199,9 @@ class DeployAddressMapper(metaclass=SingletonMeta):
         self._deployed_contracts: Dict[str, str] = {}
 
         # Set up some default mappings
-        self.add_deployed_contract(
-            "0x7109709ecfa91a80626ff3989d68f67f5b1dd12d", "HEVM_ADDRESS"
-        )
-        self.add_deployed_contract(
-            "0xf3993a62377bcd56ae39d773740a5390411e8bc9", "SVM_ADDRESS"
-        )
+        self.add_deployed_contract("0x7109709ecfa91a80626ff3989d68f67f5b1dd12d", "hevm")
+        self.add_deployed_contract("0xf3993a62377bcd56ae39d773740a5390411e8bc9", "svm")
+        self.add_deployed_contract("0x636f6e736f6c652e6c6f67", "console")
 
     def add_deployed_contract(
         self,


### PR DESCRIPTION
Before:

    CREATE Context::<500 bytes of initcode>
        CALL Context::0x318b04f10000000000000000000000000000000000000000000000000000000000000009
            CALL HEVM_ADDRESS::0xca669fa70000000000000000000000000000000000000000000000000000000000000000
            ↩ 0x
        ↩ CALL 0x (error: HalmosException('You have an active prank already.'))

After:

    CREATE Context::<500 bytes of initcode>
        CALL Context::call0(0x0000000000000000000000000000000000000000000000000000000000000009)
            CALL HEVM_ADDRESS::prank(0x0000000000000000000000000000000000000000000000000000000000000000)
            ↩ 0x
        ↩ CALL 0x (error: HalmosException('You have an active prank already.'))