### PR TITLE
ci: use yices2 for test-external

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -27,27 +27,27 @@ jobs:
             profile: ""
           - repo: "a16z/cicada"
             dir: "cicada"
-            cmd: "--contract LibUint1024Test --function testProve --loop 256 --solver-command yices-smt2"
+            cmd: "--contract LibUint1024Test --function testProve --loop 256"
             branch: ""
             profile: ""
           - repo: "a16z/cicada"
             dir: "cicada"
-            cmd: "--contract LibPrimeTest --function testProve --loop 256 --solver-command bitwuzla"
+            cmd: "--contract LibPrimeTest --function testProve --loop 256"
             branch: ""
             profile: ""
           - repo: "farcasterxyz/contracts"
             dir: "farcaster-contracts"
-            cmd: "--solver-command yices-smt2"
+            cmd: ""
             branch: ""
             profile: ""
           - repo: "zobront/halmos-solady"
             dir: "halmos-solady"
-            cmd: "--function testCheck --solver-command yices-smt2"
+            cmd: "--function testCheck"
             branch: ""
             profile: ""
           - repo: "pcaversaccio/snekmate"
             dir: "snekmate"
-            cmd: "--config test/halmos.toml --solver-command yices-smt2"
+            cmd: "--config test/halmos.toml"
             branch: ""
             profile: "halmos"
 
@@ -87,7 +87,7 @@ jobs:
         run: docker run halmos-image --version
 
       - name: Test external repo
-        run: docker run -v .:/workspace halmos-image ${{ matrix.project.cmd }} --statistics --solver-timeout-assertion 0 --solver-threads 4 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}
+        run: docker run -v .:/workspace halmos-image ${{ matrix.project.cmd }} --statistics --solver-timeout-assertion 0 --solver-threads 4 --solver-command yices-smt2 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}
         working-directory: ${{ matrix.project.dir }}
         env:
           FOUNDRY_PROFILE: ${{ matrix.project.profile }}


### PR DESCRIPTION
use yices2 for the external test, as bitwuzla in the docker image is unstable, causing the test to be flaky:
- https://github.com/a16z/halmos/actions/runs/10364288791/job/28689299861
- https://github.com/a16z/halmos/actions/runs/10103994098/job/27942255454
- https://github.com/a16z/halmos/actions/runs/10014074218/job/27683004640