### PR TITLE
ci: disable pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -n 1 -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="--debug -st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="--debug -st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         python-version: ["3.11", "3.12"]
         parallel: ["", "--test-parallel"]
         storage-layout: ["solidity", "generic"]
+        cache-solver: ["", "--cache-solver"]
 
     steps:
       - name: Checkout repository
@@ -53,4 +54,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="--debug -st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="--debug -st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}


### PR DESCRIPTION
The ci test workflow was updated to use a single worker with `pytest -n 1` in [#336](https://github.com/a16z/halmos/pull/336/files#r1702170704). However, flakiness issues persist, so let's try disabling the xdist plugin altogether.

Additionally, xdist workers crash when --cache-solver enabled. Now that xdist is disabled, tests using --cache-solver have also been added.