### PR TITLE
Code fastpath scanning for valid jump destinations

### DIFF
--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -1,0 +1,3 @@
+# optional dependencies, for benchmarking
+pytest-benchmark
+pytest-benchmark[histogram]

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -572,7 +572,7 @@ def setup(
                 f"{setup_sig}: paths have not been fully explored due to the loop unrolling bound: {args.loop}",
             )
             if args.debug:
-                print("\n".join(sevm.logs.bounded_loops))
+                print("\n".join(jumpid_str(x) for x in sevm.logs.bounded_loops))
 
     if args.reset_bytecode:
         for assign in [x.split("=") for x in args.reset_bytecode.split(",")]:
@@ -846,8 +846,7 @@ def run(
             f"{funsig}: paths have not been fully explored due to the loop unrolling bound: {args.loop}",
         )
         if args.debug:
-            for pc, jumpdests in logs.bounded_loops:
-                print(f"{pc}:{','.join(jumpdests)}")
+            print("\n".join(jumpid_str(x) for x in logs.bounded_loops))
 
     if logs.unknown_calls:
         warn_code(

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -846,7 +846,8 @@ def run(
             f"{funsig}: paths have not been fully explored due to the loop unrolling bound: {args.loop}",
         )
         if args.debug:
-            print("\n".join(logs.bounded_loops))
+            for pc, jumpdests in logs.bounded_loops:
+                print(f"{pc}:{','.join(jumpdests)}")
 
     if logs.unknown_calls:
         warn_code(

--- a/src/halmos/assertions.py
+++ b/src/halmos/assertions.py
@@ -3,7 +3,8 @@
 from dataclasses import dataclass
 from z3 import *
 
-from .utils import *
+from halmos.exceptions import HalmosException
+from halmos.utils import *
 
 
 @dataclass(frozen=True)
@@ -13,7 +14,7 @@ class VmAssertion:
     """
 
     cond: BitVecRef
-    msg: Optional
+    msg: str | None
 
 
 def mk_cond(bop, v1, v2):

--- a/src/halmos/bytevec.py
+++ b/src/halmos/bytevec.py
@@ -22,18 +22,13 @@ from .utils import (
     try_bv_value_to_bytes,
     unbox_int,
     warn,
+    Byte,
+    Word,
 )
 
-# concrete or symbolic byte
-Byte = UnionType[int, BitVecRef]
 UnwrappedBytes = UnionType[bytes, Byte]
 WrappedBytes = UnionType["Chunk", "ByteVec"]
-
-# any concrete or symbolic sequence of bytes
 Bytes = UnionType[UnwrappedBytes, WrappedBytes]
-
-# concrete or symbolic 32-byte word
-Word = UnionType[int, BitVecRef]
 
 
 def try_concat(lhs: Any, rhs: Any) -> Optional[Any]:

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -374,7 +374,7 @@ class hevm_cheat_code:
     get_block_nunber_sig: int = 0x42CBB15C
 
     @staticmethod
-    def handle(sevm, ex, arg: ByteVec, stack, step_id) -> Optional[ByteVec]:
+    def handle(sevm, ex, arg: ByteVec, stack, step_id) -> ByteVec | None:
         funsig: int = int_of(arg[:4].unwrap(), "symbolic hevm cheatcode")
         ret = ByteVec()
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0
 
-import math
 import re
 
 from copy import deepcopy

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -45,10 +45,7 @@ MAX_MEMORY_SIZE = 2**20
 
 
 # symbolic states
-# calldataload(index)
-f_calldataload = Function("f_calldataload", BitVecSort256, BitVecSort256)
-# calldatasize()
-f_calldatasize = Function("f_calldatasize", BitVecSort256)
+
 # extcodesize(target address)
 f_extcodesize = Function("f_extcodesize", BitVecSort160, BitVecSort256)
 # extcodehash(target address)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -511,14 +511,14 @@ class Contract:
         """Returns the length of the bytecode in bytes."""
         return len(self._code)
 
-    def valid_jump_destinations(self) -> set:
+    def valid_jump_destinations(self) -> set[int]:
         """Returns the set of valid jump destinations."""
         if self._jumpdests is None:
             self._jumpdests = self.__get_jumpdests()
 
         return self._jumpdests[0]
 
-    def valid_jump_destinations_str(self) -> set:
+    def valid_jump_destinations_str(self) -> set[str]:
         """Returns the set of valid jump destinations as strings."""
         if self._jumpdests is None:
             self._jumpdests = self.__get_jumpdests()

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -317,11 +317,11 @@ class State:
             # self.stack.append(v)
 
             # for now, wrap ints in a BitVec
-            v = con(v)
-
-        if not (eq(v.sort(), BitVecSort256) or is_bool(v)):
-            raise ValueError(v)
-        self.stack.append(simplify(v))
+            self.stack.append(con(v))
+        else:
+            if not (eq(v.sort(), BitVecSort256) or is_bool(v)):
+                raise ValueError(v)
+            self.stack.append(simplify(v))
 
     def pop(self) -> Word:
         return self.stack.pop()
@@ -2614,7 +2614,7 @@ class SEVM:
                     ex.emit_log(EventLog(ex.this(), topics, data))
 
                 elif opcode == EVM.PUSH0:
-                    ex.st.push(con(0))
+                    ex.st.push(0)
 
                 elif EVM.PUSH1 <= opcode <= EVM.PUSH32:
                     if is_concrete(insn.operand):

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -208,7 +208,7 @@ class Message:
     call_scheme: int
 
     is_static: bool = False
-    gas: Optional[Word] = None
+    gas: Word | None = None
 
     def is_create(self) -> bool:
         return self.call_scheme in (EVM.CREATE, EVM.CREATE2)
@@ -779,7 +779,7 @@ class Exec:  # an execution path
     def message(self):
         return self.context.message
 
-    def current_opcode(self) -> UnionType[int, BitVecRef]:
+    def current_opcode(self) -> Byte:
         return unbox_int(self.pgm[self.pc])
 
     def current_instruction(self) -> Instruction:
@@ -2441,9 +2441,7 @@ class SEVM:
                     account_addr = uint160(ex.st.pop())
                     alias_addr = self.resolve_address_alias(ex, account_addr)
                     addr = alias_addr if alias_addr is not None else account_addr
-
-                    account_code: Optional[Contract] = ex.code.get(addr, None)
-
+                    account_code: Contract | None = ex.code.get(addr)
                     codehash = (
                         f_extcodehash(addr)
                         if account_code is None

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -80,10 +80,7 @@ new_address_offset: int = 1
 
 
 def insn_len(opcode: int) -> int:
-    if EVM.PUSH1 <= opcode <= EVM.PUSH32:
-        return opcode - EVM.PUSH0 + 1
-
-    return 1
+    return 1 + (opcode - EVM.PUSH0) * (EVM.PUSH1 <= opcode <= EVM.PUSH32)
 
 
 class Instruction:
@@ -410,33 +407,23 @@ class Contract:
         pc = 0
 
         # optimistically process fast path first
-        if self._fastcode:
-            N = len(self._fastcode)
+        for bytecode in (self._fastcode, self._code):
+            if not bytecode:
+                continue
+
+            N = len(bytecode)
             while pc < N:
-                opcode = self._fastcode[pc]
-                # print(f"{pc=}, {opcode=}, {mnemonic(opcode)}")
+                try:
+                    opcode = int_of(bytecode[pc])
 
-                if opcode == EVM.JUMPDEST:
-                    jumpdests.add(pc)
+                    if opcode == EVM.JUMPDEST:
+                        jumpdests.add(pc)
 
-                next_pc = pc + insn_len(opcode)
-                self._next_pc[pc] = next_pc
-                pc = next_pc
-
-        N = len(self._code)
-        while pc < N:
-            try:
-                opcode = int_of(self._code.get_byte(pc))
-                # print(f"{pc=}, {opcode=}, {mnemonic(opcode)}")
-
-                if opcode == EVM.JUMPDEST:
-                    jumpdests.add(pc)
-
-                next_pc = pc + insn_len(opcode)
-                self._next_pc[pc] = next_pc
-                pc = next_pc
-            except NotConcreteError:
-                break
+                    next_pc = pc + insn_len(opcode)
+                    self._next_pc[pc] = next_pc
+                    pc = next_pc
+                except NotConcreteError:
+                    break
 
         return jumpdests
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1299,7 +1299,7 @@ def is_power_of_two(x: int) -> bool:
 
 
 class HalmosLogs:
-    bounded_loops: List[str]
+    bounded_loops: List[JumpID]
     unknown_calls: Dict[str, Dict[str, Set[str]]]  # funsig -> to -> set(arg)
 
     def __init__(self) -> None:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -401,6 +401,11 @@ class Contract:
         self._next_pc = dict()
         self._jumpdests = None
 
+    def __deepcopy__(self, memo):
+        # the class is essentially immutable (the only mutable fields are caches)
+        # so we can return the object itself instead of creating a new copy
+        return self
+
     def __get_jumpdests(self):
         # quick scan, does not eagerly decode instructions
         jumpdests = set()

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -45,7 +45,7 @@ MAX_MEMORY_SIZE = 2**20
 
 # (pc, (jumpdest, ...))
 # the jumpdests are stored as strings to avoid the cost of converting bv values
-type JumpID = Tuple[int, Tuple[str]]
+JumpID = Tuple[int, Tuple[str]]
 
 # symbolic states
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -541,7 +541,7 @@ class Path:
             [
                 f"- {cond}\n"
                 for cond in self.conditions
-                if self.conditions[cond] and str(cond) != "True"
+                if self.conditions[cond] and not is_true(cond)
             ]
         )
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -22,7 +22,7 @@ from typing import (
 )
 from z3 import *
 
-from .bytevec import Chunk, ByteVec
+from .bytevec import ByteVec, Chunk, ConcreteChunk, UnwrappedBytes
 from .cheatcodes import halmos_cheat_code, hevm_cheat_code, Prank
 from .config import Config as HalmosConfig
 from .console import console
@@ -82,17 +82,21 @@ create2_magic_address: int = 0xBBBB0000
 new_address_offset: int = 1
 
 
+def insn_len(opcode: int) -> int:
+    if EVM.PUSH1 <= opcode <= EVM.PUSH32:
+        return opcode - EVM.PUSH0 + 1
+
+    return 1
+
+
 class Instruction:
     opcode: int
     pc: int = -1
-    next_pc: int = -1
     operand: Optional[ByteVec] = None
 
-    def __init__(self, opcode, pc=-1, next_pc=-1, operand=None) -> None:
+    def __init__(self, opcode, pc=-1, operand=None) -> None:
         self.opcode = opcode
-
         self.pc = pc
-        self.next_pc = next_pc
         self.operand = operand
 
     def __str__(self) -> str:
@@ -103,7 +107,7 @@ class Instruction:
         return f"Instruction({mnemonic(self.opcode)}, pc={self.pc}, operand={repr(self.operand)})"
 
     def __len__(self) -> int:
-        return self.next_pc - self.pc
+        return insn_len(self.opcode)
 
 
 def id_str(x: Any) -> str:
@@ -373,22 +377,71 @@ class Block:
 class Contract:
     """Abstraction over contract bytecode. Can include concrete and symbolic elements."""
 
+    _code: ByteVec
+
+    # if the bytecode starts with a concrete prefix, we store it separately for fast access
+    # (this is a common case, especially for test contracts that deploy other contracts)
+    _fastcode: Optional[bytes] = None
+
+    _insn: Dict[int, Instruction]
+
+    _next_pc: Dict[int, int]
+
+    _jumpdests: Optional[set]
+
     def __init__(self, code: Optional[ByteVec] = None) -> None:
-        # if
         if not isinstance(code, ByteVec):
             code = ByteVec(code)
 
         self._code = code
 
+        # extract the first chunk of code
+        if code.chunks:
+            first_chunk = code.chunks[0]
+            if isinstance(first_chunk, ConcreteChunk):
+                self._fastcode = first_chunk.unwrap()
+                # print(f"{len(self._fastcode)} bytes of fastcode: {hexify(self._fastcode)}")
+
         # maps pc to decoded instruction (including operand and next_pc)
         self._insn = dict()
+        self._next_pc = dict()
+        self._jumpdests = None
 
-    def __init_jumpdests(self):
-        assert not hasattr(self, "_jumpdests")
-        self._jumpdests = set((pc for (pc, op) in iter(self) if op == EVM.JUMPDEST))
+    def __get_jumpdests(self):
+        # quick scan, does not eagerly decode instructions
+        jumpdests = set()
+        pc = 0
 
-    def __iter__(self):
-        return CodeIterator(self)
+        # optimistically process fast path first
+        if self._fastcode:
+            N = len(self._fastcode)
+            while pc < N:
+                opcode = self._fastcode[pc]
+                # print(f"{pc=}, {opcode=}, {mnemonic(opcode)}")
+
+                if opcode == EVM.JUMPDEST:
+                    jumpdests.add(pc)
+
+                next_pc = pc + insn_len(opcode)
+                self._next_pc[pc] = next_pc
+                pc = next_pc
+
+        N = len(self._code)
+        while pc < N:
+            try:
+                opcode = int_of(self._code.get_byte(pc))
+                # print(f"{pc=}, {opcode=}, {mnemonic(opcode)}")
+
+                if opcode == EVM.JUMPDEST:
+                    jumpdests.add(pc)
+
+                next_pc = pc + insn_len(opcode)
+                self._next_pc[pc] = next_pc
+                pc = next_pc
+            except NotConcreteError:
+                break
+
+        return jumpdests
 
     def from_hexcode(hexcode: str):
         """Create a contract from a hexcode string, e.g. "aabbccdd" """
@@ -409,37 +462,58 @@ class Contract:
         except ValueError as e:
             raise ValueError(f"{e} (hexcode={hexcode})")
 
-    def _decode_instruction(self, pc: int) -> Instruction:
-        opcode = int_of(self._code[pc], f"symbolic opcode at pc={pc}")
+    def _decode_instruction(self, pc: int) -> Tuple[Instruction, int]:
+        opcode = int_of(self[pc], f"symbolic opcode at pc={pc}")
+        length = insn_len(opcode)
+        next_pc = pc + length
 
-        if EVM.PUSH1 <= opcode <= EVM.PUSH32:
-            operand_offset = pc + 1
-            operand_size = opcode - EVM.PUSH0
-            next_pc = operand_offset + operand_size
-
+        if length > 1:
             # TODO: consider slicing lazily
-            operand = self.slice(operand_offset, next_pc).unwrap()
-            return Instruction(opcode, pc=pc, operand=operand, next_pc=next_pc)
+            operand = self.unwrapped_slice(pc + 1, next_pc)
+            return (Instruction(opcode, pc=pc, operand=operand), next_pc)
 
-        return Instruction(opcode, pc=pc, next_pc=pc + 1)
+        return (Instruction(opcode, pc=pc), next_pc)
 
     def decode_instruction(self, pc: int) -> Instruction:
+        """decode instruction at pc and cache the result"""
+
         insn = self._insn.get(pc, None)
         if insn is None:
-            insn = self._decode_instruction(pc)
+            insn, next_pc = self._decode_instruction(pc)
             self._insn[pc] = insn
+            self._next_pc[pc] = next_pc
 
         return insn
 
     def next_pc(self, pc):
-        return self.decode_instruction(pc).next_pc
+        if (result := self._next_pc.get(pc)) is not None:
+            return result
+
+        self.decode_instruction(pc)
+        return self._next_pc[pc]
 
     def slice(self, start, stop) -> ByteVec:
+        # fast path for offsets in the concrete prefix
+        if self._fastcode and stop < len(self._fastcode):
+            return ByteVec(self._fastcode[start:stop])
+
         return self._code.slice(start, stop)
+
+    def unwrapped_slice(self, start, stop) -> UnwrappedBytes:
+        # fast path for offsets in the concrete prefix
+        if self._fastcode and stop < len(self._fastcode):
+            return self._fastcode[start:stop]
+
+        return self._code.slice(start, stop).unwrap()
 
     def __getitem__(self, key: int) -> Byte:
         """Returns the byte at the given offset."""
         offset = int_of(key, "symbolic index into contract bytecode {offset!r}")
+
+        # fast path for offsets in the concrete prefix
+        if self._fastcode and offset < len(self._fastcode):
+            return self._fastcode[offset]
+
         return self._code.get_byte(offset)
 
     def __len__(self) -> int:
@@ -448,32 +522,10 @@ class Contract:
 
     def valid_jump_destinations(self) -> set:
         """Returns the set of valid jump destinations."""
-        if not hasattr(self, "_jumpdests"):
-            self.__init_jumpdests()
+        if self._jumpdests is None:
+            self._jumpdests = self.__get_jumpdests()
 
         return self._jumpdests
-
-
-class CodeIterator:
-    def __init__(self, contract: Contract):
-        self.contract = contract
-        self.pc = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self) -> Tuple[int, int]:
-        """Returns a tuple of (pc, opcode)"""
-        if self.pc >= len(self.contract):
-            raise StopIteration
-
-        try:
-            pc = self.pc
-            insn = self.contract.decode_instruction(pc)
-            self.pc = insn.next_pc
-            return (pc, insn.opcode)
-        except NotConcreteError:
-            raise StopIteration
 
 
 @dataclass(frozen=True)
@@ -788,7 +840,7 @@ class Exec:  # an execution path
             )
         )
 
-    def next_pc(self) -> None:
+    def advance_pc(self) -> None:
         self.pc = self.pgm.next_pc(self.pc)
 
     def check(self, cond: Any) -> Any:
@@ -1678,7 +1730,7 @@ class SEVM:
                     new_ex.balance = orig_balance
 
                 # add to worklist even if it reverted during the external call
-                new_ex.next_pc()
+                new_ex.advance_pc()
                 stack.push(new_ex, step_id)
 
             sub_ex = Exec(
@@ -1836,7 +1888,7 @@ class SEVM:
             # TODO: check if still needed
             ex.calls.append((exit_code_var, exit_code, ex.context.output.data))
 
-            ex.next_pc()
+            ex.advance_pc()
             stack.push(ex, step_id)
 
         # precompiles or cheatcodes
@@ -1932,7 +1984,7 @@ class SEVM:
         if new_addr in ex.code:
             # address conflicts don't revert, they push 0 on the stack and continue
             ex.st.push(0)
-            ex.next_pc()
+            ex.advance_pc()
 
             # add a virtual subcontext to the trace for debugging purposes
             subcall = CallContext(message=message, depth=ex.context.depth + 1)
@@ -1958,7 +2010,7 @@ class SEVM:
         # transfer value
         self.transfer_value(ex, pranked_caller, new_addr, value)
 
-        def callback(new_ex, stack, step_id):
+        def callback(new_ex: Exec, stack, step_id):
             subcall = new_ex.context
 
             # continue execution in the context of the parent
@@ -1996,7 +2048,7 @@ class SEVM:
                 new_ex.balance = orig_balance
 
             # add to worklist
-            new_ex.next_pc()
+            new_ex.advance_pc()
             stack.push(new_ex, step_id)
 
         sub_ex = Exec(
@@ -2079,7 +2131,7 @@ class SEVM:
         if follow_false:
             new_ex_false = ex
             new_ex_false.path.append(cond_false, branching=True)
-            new_ex_false.next_pc()
+            new_ex_false.advance_pc()
 
         if new_ex_true:
             if potential_true and potential_false:
@@ -2605,7 +2657,7 @@ class SEVM:
                     # this halts the path, but we should only halt the current context
                     raise HalmosException(f"Unsupported opcode {hex(opcode)}")
 
-                ex.next_pc()
+                ex.advance_pc()
                 stack.push(ex, step_id)
 
             except InfeasiblePath as err:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -327,7 +327,7 @@ class State:
         return self.stack.pop()
 
     def dup(self, n: int) -> None:
-        self.push(self.stack[-n])
+        self.stack.append(self.stack[-n])
 
     def swap(self, n: int) -> None:
         self.stack[-(n + 1)], self.stack[-1] = self.stack[-1], self.stack[-(n + 1)]

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -382,6 +382,7 @@ class Contract:
             code = ByteVec(code)
 
         self._code = code
+        self._fastcode = None
 
         # if the bytecode starts with a concrete prefix, we store it separately for fast access
         # (this is a common case, especially for test contracts that deploy other contracts)
@@ -460,8 +461,7 @@ class Contract:
     def decode_instruction(self, pc: int) -> Instruction:
         """decode instruction at pc and cache the result"""
 
-        insn = self._insn.get(pc, None)
-        if insn is None:
+        if (insn := self._insn.get(pc)) is None:
             insn, next_pc = self._decode_instruction(pc)
             self._insn[pc] = insn
             self._next_pc[pc] = next_pc

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2618,20 +2618,19 @@ class SEVM:
                     ex.st.push(0)
 
                 elif EVM.PUSH1 <= opcode <= EVM.PUSH32:
-                    if is_concrete(insn.operand):
-                        val = int_of(insn.operand)
+                    val = unbox_int(insn.operand)
+                    if isinstance(val, int):
                         if opcode == EVM.PUSH32 and val in sha3_inv:
                             # restore precomputed hashes
                             ex.st.push(ex.sha3_data(con(sha3_inv[val])))
                         else:
-                            ex.st.push(con(val))
+                            ex.st.push(val)
                     else:
-                        if opcode == EVM.PUSH32:
-                            ex.st.push(insn.operand)
-                        else:
-                            ex.st.push(ZeroExt((EVM.PUSH32 - opcode) * 8, insn.operand))
+                        ex.st.push(uint256(val) if opcode < EVM.PUSH32 else val)
+
                 elif EVM.DUP1 <= opcode <= EVM.DUP16:
                     ex.st.dup(opcode - EVM.DUP1 + 1)
+
                 elif EVM.SWAP1 <= opcode <= EVM.SWAP16:
                     ex.st.swap(opcode - EVM.SWAP1 + 1)
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -372,15 +372,9 @@ class Contract:
     """Abstraction over contract bytecode. Can include concrete and symbolic elements."""
 
     _code: ByteVec
-
-    # if the bytecode starts with a concrete prefix, we store it separately for fast access
-    # (this is a common case, especially for test contracts that deploy other contracts)
-    _fastcode: Optional[bytes] = None
-
+    _fastcode: Optional[bytes]
     _insn: Dict[int, Instruction]
-
     _next_pc: Dict[int, int]
-
     _jumpdests: Optional[set]
 
     def __init__(self, code: Optional[ByteVec] = None) -> None:
@@ -389,12 +383,12 @@ class Contract:
 
         self._code = code
 
-        # extract the first chunk of code
+        # if the bytecode starts with a concrete prefix, we store it separately for fast access
+        # (this is a common case, especially for test contracts that deploy other contracts)
         if code.chunks:
             first_chunk = code.chunks[0]
             if isinstance(first_chunk, ConcreteChunk):
                 self._fastcode = first_chunk.unwrap()
-                # print(f"{len(self._fastcode)} bytes of fastcode: {hexify(self._fastcode)}")
 
         # maps pc to decoded instruction (including operand and next_pc)
         self._insn = dict()

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -220,10 +220,10 @@ class CallOutput:
     Data record produced during the execution of a call.
     """
 
-    data: Optional[ByteVec] = None
+    data: ByteVec | None = None
     accounts_to_delete: Set[Address] = field(default_factory=set)
-    error: Optional[UnionType[EvmException, HalmosException]] = None
-    return_scheme: Optional[int] = None
+    error: EvmException | HalmosException | None = None
+    return_scheme: int | None = None
 
     # TODO:
     #   - touched_accounts
@@ -756,6 +756,15 @@ class Exec:  # an execution path
 
     def is_halted(self) -> bool:
         return self.context.output.data is not None
+
+    def reverted_with(self, expected: ByteVec) -> bool:
+        if not isinstance(self.context.output.error, Revert):
+            return False
+
+        returndata = self.context.output.data[: byte_length(expected)]
+
+        # bytevec equality check, will take care of length check, bv vs symbolic, etc.
+        return returndata == expected
 
     def emit_log(self, log: EventLog):
         self.context.trace.append(log)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -82,6 +82,11 @@ create2_magic_address: int = 0xBBBB0000
 new_address_offset: int = 1
 
 
+def jumpid_str(jumpid: JumpID) -> str:
+    pc, jumpdests = jumpid
+    return f"{pc}:{','.join(jumpdests)}"
+
+
 def insn_len(opcode: int) -> int:
     return 1 + (opcode - EVM.PUSH0) * (EVM.PUSH1 <= opcode <= EVM.PUSH32)
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -297,9 +297,6 @@ def unbox_int(x: Any) -> Any:
     if is_bv_value(x):
         return x.as_long()
 
-    if is_bv(x):
-        x = simplify(x)
-
     return x
 
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -3,24 +3,23 @@
 import re
 from functools import partial
 from timeit import default_timer as timer
-from typing import Any, Dict, Optional, Tuple
-from typing import Union as UnionType
+from typing import Any, Dict, Tuple
 
 from z3 import *
 
 from halmos.mapper import Mapper
-
-from .exceptions import HalmosException, NotConcreteError
+from halmos.exceptions import HalmosException, NotConcreteError
 
 # order of the secp256k1 curve
 secp256k1n = (
     115792089237316195423570985008687907852837564279074904382605163141518161494337
 )
 
-Word = Any  # z3 expression (including constants)
-Byte = Any  # z3 expression (including constants)
-Bytes = Any  # z3 expression (including constants)
-Address = BitVecRef  # 160-bitvector
+Byte = int | BitVecRef  # uint8
+Bytes4 = int | BitVecRef  # uint32
+Address = int | BitVecRef  # uint160
+Word = int | BitVecRef  # uint256
+Bytes = bytes | BitVecRef  # arbitrary-length sequence of bytes
 
 
 # dynamic BitVecSort sizes
@@ -112,7 +111,7 @@ def uint(x: Any, n: int) -> Word:
     return simplify(ZeroExt(n - bitsize, x))
 
 
-def uint8(x: UnionType[Word, Byte]) -> Byte:
+def uint8(x: Any) -> Byte:
     return uint(x, 8)
 
 
@@ -262,7 +261,7 @@ def extract_bytes(data: Bytes, offset: int, size_bytes: int) -> Bytes:
     return val
 
 
-def extract_funsig(calldata: Bytes) -> Any:
+def extract_funsig(calldata: Bytes) -> Bytes4:
     """Extracts the function signature (first 4 bytes) from calldata"""
     if hasattr(calldata, "__getitem__"):
         return unbox_int(calldata[:4])
@@ -273,7 +272,7 @@ def bv_value_to_bytes(x: BitVecNumRef) -> bytes:
     return x.as_long().to_bytes(byte_length(x, strict=True), "big")
 
 
-def try_bv_value_to_bytes(x: Any) -> Optional[bytes]:
+def try_bv_value_to_bytes(x: Any) -> Any:
     return bv_value_to_bytes(x) if is_bv_value(x) else x
 
 
@@ -283,7 +282,7 @@ def bytes_to_bv_value(x: bytes) -> BitVecNumRef:
 
 def unbox_int(x: Any) -> Any:
     """
-    Attempts to convert int-like objects to int
+    Converts int-like objects to int, returns x otherwise
     """
     if isinstance(x, int):
         return x
@@ -330,7 +329,7 @@ def stripped(hexstring: str) -> str:
     return hexstring[2:] if hexstring.startswith("0x") else hexstring
 
 
-def decode_hex(hexstring: str) -> Optional[bytes]:
+def decode_hex(hexstring: str) -> bytes | None:
     try:
         # not checking if length is even because fromhex accepts spaces
         return bytes.fromhex(stripped(hexstring))
@@ -384,7 +383,7 @@ def render_string(s: BitVecRef) -> str:
     return f'"{str_val}"'
 
 
-def render_bytes(b: UnionType[BitVecRef, bytes]) -> str:
+def render_bytes(b: Bytes) -> str:
     if is_bv(b):
         return hexify(b) + f" ({byte_length(b, strict=False)} bytes)"
     else:

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -77,6 +77,15 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_symbolic_revert(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/Block.t.sol:BlockCheatCodeTest": [

--- a/tests/regression/test/AssertTest.t.sol
+++ b/tests/regression/test/AssertTest.t.sol
@@ -27,4 +27,16 @@ contract AssertTest is Test {
     function check_fail_propagated() public {
         address(c).call(abi.encodeWithSelector(C.bar.selector, bytes(""))); // fail
     }
+
+    function check_symbolic_revert(uint256 x) public {
+        // reverts with Concat(0x4e487b71, p_x_uint256())
+        // halmos only considers reverts with explicit revert codes so we expect a PASS here
+        // this is really to make sure we handle symbolic reverts gracefully
+        if (x > 0) {
+            bytes memory data = abi.encodeWithSignature("Panic(uint256)", x);
+            assembly {
+                revert(add(data, 0x20), mload(data))
+            }
+        }
+    }
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,7 +105,9 @@ def test_decode_mixed_bytecode():
 
 
 def test_run_bytecode(args):
-    args = args.with_overrides(source="test_run_bytecode", symbolic_jump=True)
+    args = args.with_overrides(
+        source="test_run_bytecode", symbolic_jump=True, print_steps=True
+    )
 
     hexcode = "34381856FDFDFDFDFDFD5B00"
     exs = run_bytecode(hexcode, args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,10 +57,6 @@ def test_decode_concrete_bytecode():
     assert contract[10] == EVM.JUMPDEST
     assert contract[11] == EVM.STOP
 
-    # iteration
-    opcodes = [opcode for (pc, opcode) in contract]
-    assert bytes(opcodes).hex() == hexcode.lower()
-
     # jump destination scanning
     assert contract.valid_jump_destinations() == set([10])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,9 +4,7 @@ import json
 from z3 import *
 
 from halmos.utils import EVM, hexify
-
 from halmos.sevm import con, Contract, Instruction
-
 from halmos.__main__ import str_abi, run_bytecode, FunctionInfo
 
 from test_fixtures import args
@@ -79,8 +77,16 @@ def test_decode_mixed_bytecode():
     assert contract[27] == EVM.RETURN
     assert contract[28] == EVM.STOP  # past the end
 
-    # iteration
-    pcs, opcodes = zip(*iter(contract))
+    contract.valid_jump_destinations() == set()
+
+    # force decoding
+    pc = 0
+    while pc < len(contract):
+        contract.decode_instruction(pc)
+        pc = contract.next_pc(pc)
+
+    pcs, insns = zip(*((pc, insn) for (pc, insn) in contract._insn.items()))
+    opcodes = tuple(insn.opcode for insn in insns)
 
     assert opcodes == (
         EVM.PUSH20,
@@ -91,7 +97,7 @@ def test_decode_mixed_bytecode():
         EVM.RETURN,
     )
 
-    disassembly = " ".join([str(contract.decode_instruction(pc)) for pc in pcs])
+    disassembly = " ".join([str(insn) for insn in insns])
     assert disassembly == "PUSH20 x() PUSH0 MSTORE PUSH1 0x14 PUSH1 0x0c RETURN"
 
     # jump destination scanning
@@ -130,11 +136,9 @@ def test_instruction():
 def test_decode_hex():
     code = Contract.from_hexcode("600100")
     assert str(code.decode_instruction(0)) == f"PUSH1 {hexify(1)}"
-    assert [opcode for (pc, opcode) in code] == [0x60, 0x00]
 
     code = Contract.from_hexcode("01")
     assert str(code.decode_instruction(0)) == "ADD"
-    assert [opcode for (pc, opcode) in code] == [1]
 
     with pytest.raises(ValueError, match="1"):
         Contract.from_hexcode("1")
@@ -151,8 +155,6 @@ def test_decode():
     assert str(code[31]) == "Extract(7, 0, x)"
 
     code = Contract(Concat(BitVecVal(EVM.PUSH3, 8), BitVec("x", 16)))
-    ops = list(code)
-    assert len(ops) == 1
     assert (
         str(code.decode_instruction(0)) == "PUSH3 Concat(x(), 0x00)"
     )  # 'PUSH3 ERROR x (1 bytes missed)'


### PR DESCRIPTION
`jumpi_id()` keeps showing up when I profile tests, because it causes us to eagerly compute `valid_jump_destinations()`

Fundamentally, `valid_jump_destinations()` does a linear scan of the whole code for a contract. Even though ByteVec avoids z3 operations for this, it's still not ideal to do 10k+ individual byte lookups in a bytevec for almost contiguous data.

The insight here is that it is quite common to process contracts that have a large concrete prefix, sometimes followed by some symbolic data. In this case, we extract the concrete prefix in `_fastcode` and scan that first for valid jump destinations.

With this change, the regression tests run about 15% faster for me (44s to 37s)