### PR TITLE
feat: branching over symbolic call addresses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="--debug -st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st ${{ matrix.parallel }} --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st ${{ matrix.parallel }} --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -439,7 +439,7 @@ def deploy_test(
     # use the given deployed bytecode if --no-test-constructor is enabled
     if args.no_test_constructor:
         deployed_bytecode = Contract.from_hexcode(deployed_hexcode)
-        ex.code[this] = deployed_bytecode
+        ex.set_code(this, deployed_bytecode)
         ex.pgm = deployed_bytecode
         return ex
 
@@ -462,7 +462,7 @@ def deploy_test(
         raise ValueError(f"constructor failed, error={error} returndata={returndata}")
 
     deployed_bytecode = Contract(returndata)
-    ex.code[this] = deployed_bytecode
+    ex.set_code(this, deployed_bytecode)
     ex.pgm = deployed_bytecode
 
     # reset vm state
@@ -581,7 +581,7 @@ def setup(
         for assign in [x.split("=") for x in args.reset_bytecode.split(",")]:
             addr = con_addr(int(assign[0].strip(), 0))
             new_hexcode = assign[1].strip()
-            setup_ex.code[addr] = Contract.from_hexcode(new_hexcode)
+            setup_ex.set_code(addr, Contract.from_hexcode(new_hexcode))
 
     if args.statistics:
         print(setup_timer.report())

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -192,7 +192,10 @@ def mk_caller(args: HalmosConfig) -> Address:
 
 
 def mk_this() -> Address:
-    return magic_address + 1
+    # NOTE: Do NOT remove the `con_addr()` wrapper.
+    #       The return type should be BitVecSort(160) as it is used as a key for ex.code.
+    #       The keys of ex.code are compared using structural equality with other BitVecRef addresses.
+    return con_addr(magic_address + 1)
 
 
 def mk_solver(args: HalmosConfig, logic="QF_AUFBV", ctx=None, assertion=False):

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -688,7 +688,6 @@ def run(
             sha3s=setup_ex.sha3s.copy(),
             storages=setup_ex.storages.copy(),
             balances=setup_ex.balances.copy(),
-            calls=setup_ex.calls.copy(),
         )
     )
 

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1094,7 +1094,7 @@ def solve(
             )
 
         with open(dump_filename, "w") as f:
-            if args.verbose >= 1:
+            if args.debug:
                 print(f"Writing SMT query to {dump_filename}")
             if args.cache_solver:
                 f.write("(set-option :produce-unsat-cores true)\n")
@@ -1108,7 +1108,7 @@ def solve(
                 f.write("(get-unsat-core)\n")
 
     if args.solver_command:
-        if args.verbose >= 1:
+        if args.debug:
             print(f"  Checking with external solver process")
             print(f"    {args.solver_command} {dump_filename} >{dump_filename}.out")
 
@@ -1128,7 +1128,7 @@ def solve(
             with open(f"{dump_filename}.out", "w") as f:
                 f.write(res_str)
 
-            if args.verbose >= 1:
+            if args.debug:
                 print(f"    {res_str_head}")
 
             if res_str_head == "unsat":

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -847,14 +847,6 @@ def run(
         if args.debug:
             print("\n".join(logs.bounded_loops))
 
-    if logs.unknown_calls:
-        warn_code(
-            UNINTERPRETED_UNKNOWN_CALLS,
-            f"{funsig}: unknown calls have been assumed to be static: {', '.join(logs.unknown_calls)}",
-        )
-        if args.debug:
-            logs.print_unknown_calls()
-
     # print post-states
     if args.print_states:
         for idx, ex in enumerate(result_exs):

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -477,7 +477,9 @@ class hevm_cheat_code:
             store_account = uint160(arg.get_word(4))
             store_slot = uint256(arg.get_word(36))
             store_value = uint256(arg.get_word(68))
-            store_account_addr = sevm.resolve_address_alias(ex, store_account, stack, step_id)
+            store_account_addr = sevm.resolve_address_alias(
+                ex, store_account, stack, step_id
+            )
             if store_account_addr is None:
                 raise HalmosException(f"uninitialized account: {hexify(store_account)}")
 
@@ -488,7 +490,9 @@ class hevm_cheat_code:
         elif funsig == hevm_cheat_code.load_sig:
             load_account = uint160(arg.get_word(4))
             load_slot = uint256(arg.get_word(36))
-            load_account_addr = sevm.resolve_address_alias(ex, load_account, stack, step_id)
+            load_account_addr = sevm.resolve_address_alias(
+                ex, load_account, stack, step_id
+            )
             if load_account_addr is None:
                 raise HalmosException(f"uninitialized account: {load_account}")
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -477,7 +477,7 @@ class hevm_cheat_code:
             store_account = uint160(arg.get_word(4))
             store_slot = uint256(arg.get_word(36))
             store_value = uint256(arg.get_word(68))
-            store_account_addr = sevm.resolve_address_alias(ex, store_account)
+            store_account_addr = sevm.resolve_address_alias(ex, store_account, stack, step_id)
             if store_account_addr is None:
                 raise HalmosException(f"uninitialized account: {hexify(store_account)}")
 
@@ -488,7 +488,7 @@ class hevm_cheat_code:
         elif funsig == hevm_cheat_code.load_sig:
             load_account = uint160(arg.get_word(4))
             load_slot = uint256(arg.get_word(36))
-            load_account_addr = sevm.resolve_address_alias(ex, load_account)
+            load_account_addr = sevm.resolve_address_alias(ex, load_account, stack, step_id)
             if load_account_addr is None:
                 raise HalmosException(f"uninitialized account: {load_account}")
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -477,26 +477,22 @@ class hevm_cheat_code:
             store_account = uint160(arg.get_word(4))
             store_slot = uint256(arg.get_word(36))
             store_value = uint256(arg.get_word(68))
-            store_account_addr = sevm.resolve_address_alias(
-                ex, store_account, stack, step_id
+            store_account_alias = sevm.resolve_address_alias(
+                ex, store_account, stack, step_id, branching=False
             )
-            if store_account_addr is None:
-                raise HalmosException(f"uninitialized account: {hexify(store_account)}")
 
-            sevm.sstore(ex, store_account_addr, store_slot, store_value)
+            sevm.sstore(ex, store_account_alias, store_slot, store_value)
             return ret
 
         # vm.load(address,bytes32)
         elif funsig == hevm_cheat_code.load_sig:
             load_account = uint160(arg.get_word(4))
             load_slot = uint256(arg.get_word(36))
-            load_account_addr = sevm.resolve_address_alias(
-                ex, load_account, stack, step_id
+            load_account_alias = sevm.resolve_address_alias(
+                ex, load_account, stack, step_id, branching=False
             )
-            if load_account_addr is None:
-                raise HalmosException(f"uninitialized account: {load_account}")
 
-            return ByteVec(sevm.sload(ex, load_account_addr, load_slot))
+            return ByteVec(sevm.sload(ex, load_account_alias, load_slot))
 
         # vm.fee(uint256)
         elif funsig == hevm_cheat_code.fee_sig:

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -153,23 +153,6 @@ class Config:
         metavar="NAME1=LENGTH1,NAME2=LENGTH2,...",
     )
 
-    # default set of selectors:
-    # - IERC721.onERC721Received
-    # - IERC1271.isValidSignature
-    # - IERC1155.onERC1155Received
-    # - IERC1155.onERC1155BatchReceived
-    uninterpreted_unknown_calls: str = arg(
-        help="use uninterpreted abstractions for unknown external calls with the given function signatures",
-        global_default="0x150b7a02,0x1626ba7e,0xf23a6e61,0xbc197c81",
-        metavar="SELECTOR1,SELECTOR2,...",
-    )
-
-    return_size_of_unknown_calls: int = arg(
-        help="set the byte size of return data from uninterpreted unknown external calls",
-        global_default=32,
-        metavar="BYTE_SIZE",
-    )
-
     storage_layout: str = arg(
         help="Select one of the available storage layout models. The generic model should only be necessary for vyper, huff, or unconventional storage patterns in yul.",
         global_default="solidity",
@@ -387,6 +370,25 @@ class Config:
     solver_parallel: bool = arg(
         help="(Deprecated; no-op; use --solver-threads instead) run assertion solvers in parallel",
         global_default=False,
+        group=deprecated,
+    )
+
+    # default set of selectors:
+    # - IERC721.onERC721Received
+    # - IERC1271.isValidSignature
+    # - IERC1155.onERC1155Received
+    # - IERC1155.onERC1155BatchReceived
+    uninterpreted_unknown_calls: str = arg(
+        help="(Deprecated; no-op) use uninterpreted abstractions for unknown external calls with the given function signatures",
+        global_default="0x150b7a02,0x1626ba7e,0xf23a6e61,0xbc197c81",
+        metavar="SELECTOR1,SELECTOR2,...",
+        group=deprecated,
+    )
+
+    return_size_of_unknown_calls: int = arg(
+        help="(Deprecated; no-op) set the byte size of return data from uninterpreted unknown external calls",
+        global_default=32,
+        metavar="BYTE_SIZE",
         group=deprecated,
     )
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1823,6 +1823,7 @@ class SEVM:
             # non-existing contracts
             else:
                 # in evm, calls to non-existing contracts always succeed with empty returndata
+                # TODO: exitcode should be 0 when balance is not enough for callvalue
                 exit_code = con(1)
                 ret = ByteVec()
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2361,7 +2361,7 @@ class SEVM:
                         or eq(account, halmos_cheat_code.address)
                         or eq(account, console.address)
                     ):
-                        codesize = 777  # dummy arbitrary value
+                        codesize = 1  # dummy arbitrary value, consistent with foundry
                     else:
                         codesize = 0
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1555,13 +1555,14 @@ class SEVM:
         if not potential_aliases:
             raise InfeasiblePath("resolve_address_alias: no potential aliases")
 
-        if len(potential_aliases) > 1:
-            for addr, cond in potential_aliases[1:]:
-                new_ex = self.create_branch(ex, cond, ex.pc)
-                new_ex.alias[target] = addr
-                stack.push(new_ex, step_id)
-
-        addr, cond = potential_aliases[0]
+        head, *tail = potential_aliases
+    
+        for addr, cond in tail:
+            new_ex = self.create_branch(ex, cond, ex.pc)
+            new_ex.alias[target] = addr
+            stack.push(new_ex, step_id)
+    
+        addr, cond = head
         ex.path.append(cond)
         ex.alias[target] = addr
         return addr

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2481,7 +2481,7 @@ class SEVM:
                     addr = alias_addr if alias_addr is not None else account_addr
                     account_code: Contract | None = ex.code.get(addr)
                     codehash = (
-                        con(0)
+                        ZERO  # vs EMPTY_KECCAK, see EIP-1052
                         if account_code is None
                         else ex.sha3_data(account_code._code.unwrap())
                     )

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1525,7 +1525,12 @@ class SEVM:
         if target in ex.code:
             return target
 
+        if self.options.debug:
+            debug(f"Address {hexify(target)} not in: [{", ".join([hexify(addr) for addr in ex.code])}]")
+
         if is_bv_value(target):
+            if self.options.debug:
+                debug(f"Empty address: {hexify(target)}")
             return None
 
         if target in ex.alias:
@@ -1536,13 +1541,13 @@ class SEVM:
             alias_cond = target == addr
             if ex.check(alias_cond) != unsat:
                 if self.options.debug:
-                    debug(f"Address alias: {hexify(addr)} for {hexify(target)}")
+                    debug(f"Potential address alias: {hexify(addr)} for {hexify(target)}")
                 potential_aliases.append((addr, alias_cond))
 
         emptyness_cond = And([ target != addr for addr in ex.code ])
         if ex.check(emptyness_cond) != unsat:
             if self.options.debug:
-                debug(f"Address empty: {hexify(target)}")
+                debug(f"Potential empty address: {hexify(target)}")
             potential_aliases.append((None, emptyness_cond))
 
         if len(potential_aliases) == 0:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -646,7 +646,6 @@ class Exec:  # an execution path
     sha3s: Dict[Word, int]  # sha3 hashes generated
     storages: Dict[Any, Any]  # storage updates
     balances: Dict[Any, Any]  # balance updates
-    calls: List[Any]  # external calls
     known_keys: Dict[Any, Any]  # maps address to private key
     known_sigs: Dict[Any, Any]  # maps (private_key, digest) to (v, r, s)
 
@@ -674,7 +673,6 @@ class Exec:  # an execution path
         self.sha3s = kwargs["sha3s"]
         self.storages = kwargs["storages"]
         self.balances = kwargs["balances"]
-        self.calls = kwargs["calls"]
         self.known_keys = kwargs["known_keys"] if "known_keys" in kwargs else {}
         self.known_sigs = kwargs["known_sigs"] if "known_sigs" in kwargs else {}
 
@@ -785,8 +783,6 @@ class Exec:  # an execution path
                     ),
                     f"SHA3 hashes:\n",
                     "".join(map(lambda x: f"- {self.sha3s[x]}: {x}\n", self.sha3s)),
-                    f"External calls:\n",
-                    "".join(map(lambda x: f"- {x}\n", self.calls)),
                 ]
             )
         )
@@ -1725,7 +1721,6 @@ class SEVM:
                 sha3s=ex.sha3s,
                 storages=ex.storages,
                 balances=ex.balances,
-                calls=ex.calls,
                 known_keys=ex.known_keys,
                 known_sigs=ex.known_sigs,
             )
@@ -2049,7 +2044,6 @@ class SEVM:
             sha3s=ex.sha3s,
             storages=ex.storages,
             balances=ex.balances,
-            calls=ex.calls,
             known_keys=ex.known_keys,
             known_sigs=ex.known_sigs,
         )
@@ -2167,7 +2161,6 @@ class SEVM:
             sha3s=ex.sha3s.copy(),
             storages=ex.storages.copy(),
             balances=ex.balances.copy(),
-            calls=ex.calls.copy(),
             known_keys=ex.known_keys,  # pass by reference, not need to copy
             known_sigs=ex.known_sigs,  # pass by reference, not need to copy
         )
@@ -2704,5 +2697,4 @@ class SEVM:
             sha3s={},
             storages={},
             balances={},
-            calls=[],
         )

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1290,10 +1290,6 @@ class SEVM:
         self.logs = HalmosLogs()
         self.steps: Steps = {}
 
-        # init unknown calls
-        hex_string = options.uninterpreted_unknown_calls.strip()
-        self.unknown_calls: List[int] = [int(x, 16) for x in hex_string.split(",") if x]
-
         # init storage model
         is_generic = self.options.storage_layout == "generic"
         self.storage_model = GenericStorage if is_generic else SolidityStorage

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -949,9 +949,8 @@ class Exec:  # an execution path
             for lib in lib_references:
                 address = self.new_address()
 
-                self.code[address] = Contract.from_hexcode(
-                    lib_references[lib]["hexcode"]
-                )
+                lib_bytecode = Contract.from_hexcode(lib_references[lib]["hexcode"])
+                self.set_code(address, lib_bytecode)
 
                 placeholder = lib_references[lib]["placeholder"]
                 hex_address = stripped(hex(address.as_long())).zfill(40)
@@ -1961,7 +1960,7 @@ class SEVM:
         orig_balance = ex.balance
 
         # setup new account
-        ex.code[new_addr] = Contract(b"")  # existing code must be empty
+        ex.set_code(new_addr, Contract(b""))  # existing code must be empty
         ex.storage[new_addr] = {}  # existing storage may not be empty and reset here
 
         # transfer value
@@ -1990,7 +1989,7 @@ class SEVM:
 
             elif subcall.output.error is None:
                 # new contract code, will revert if data is None
-                new_ex.code[new_addr] = Contract(subcall.output.data)
+                new_ex.set_code(new_addr, Contract(subcall.output.data))
 
                 # push new address to stack
                 new_ex.st.push(uint256(new_addr))

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -742,6 +742,7 @@ class Exec:  # an execution path
         """
         Sets the code at a given address.
         """
+        assert_bv(who)
         assert_address(who)
         self.code[who] = code if isinstance(code, Contract) else Contract(code)
 
@@ -1519,6 +1520,9 @@ class SEVM:
     def resolve_address_alias(
         self, ex: Exec, target: Address, stack, step_id
     ) -> Address:
+        assert_bv(target)
+        assert_address(target)
+
         if target in ex.code:
             return target
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1584,7 +1584,7 @@ class SEVM:
         self.storage_model.store(ex, addr, loc, val)
 
     def resolve_address_alias(
-        self, ex: Exec, target: Address, stack, step_id
+        self, ex: Exec, target: Address, stack, step_id, branching=True
     ) -> Address:
         assert_bv(target)
         assert_address(target)
@@ -1625,6 +1625,9 @@ class SEVM:
             raise InfeasiblePath("resolve_address_alias: no potential aliases")
 
         head, *tail = potential_aliases
+
+        if not branching and tail:
+            raise HalmosException(f"multiple aliases exist: {hexify(target)}")
 
         for addr, cond in tail:
             new_ex = self.create_branch(ex, cond, ex.pc)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1556,12 +1556,12 @@ class SEVM:
             raise InfeasiblePath("resolve_address_alias: no potential aliases")
 
         head, *tail = potential_aliases
-    
+
         for addr, cond in tail:
             new_ex = self.create_branch(ex, cond, ex.pc)
             new_ex.alias[target] = addr
             stack.push(new_ex, step_id)
-    
+
         addr, cond = head
         ex.path.append(cond)
         ex.alias[target] = addr

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1748,12 +1748,79 @@ class SEVM:
                 r = extract_bytes(arg, 64, 32)
                 s = extract_bytes(arg, 96, 32)
 
+                # TODO: empty returndata in error
                 ret = ByteVec(uint256(f_ecrecover(digest, v, r, s)))
+
+            # sha256
+            elif eq(to, con_addr(2)):
+                exit_code = con(1)
+                f_sha256 = Function(
+                    f"f_sha256_{arg_size}", BitVecSorts[arg_size], BitVecSort256
+                )
+                ret = ByteVec(f_sha256(arg))
+
+            # ripemd160
+            elif eq(to, con_addr(3)):
+                exit_code = con(1)
+                f_ripemd160 = Function(
+                    f"f_ripemd160_{arg_size}", BitVecSorts[arg_size], BitVecSort160
+                )
+                ret = ByteVec(uint256(f_ripemd160(arg)))
 
             # identity
             elif eq(to, con_addr(4)):
                 exit_code = con(1)
                 ret = arg
+
+            # modexp
+            elif eq(to, con_addr(5)):
+                exit_code = con(1)
+                modulus_size = int_of(extract_bytes(arg, 64, 32))
+                f_modexp = Function(
+                    f"f_modexp_{arg_size}_{modulus_size}", BitVecSorts[arg_size], BitVecSorts[modulus_size]
+                )
+                # TODO: empty returndata in error
+                ret = ByteVec(f_modexp(arg))
+
+            # ecadd
+            elif eq(to, con_addr(6)):
+                exit_code = con(1)
+                f_ecadd = Function(
+                    f"f_ecadd", BitVecSorts[1024], BitVecSorts[512]
+                )
+                ret = ByteVec(f_ecadd(arg))
+
+            # ecmul
+            elif eq(to, con_addr(7)):
+                exit_code = con(1)
+                f_ecmul = Function(
+                    f"f_ecmul", BitVecSorts[768], BitVecSorts[512]
+                )
+                ret = ByteVec(f_ecmul(arg))
+
+            # ecpairing
+            elif eq(to, con_addr(8)):
+                exit_code = con(1)
+                f_ecpairing = Function(
+                    f"f_ecpairing", BitVecSorts[1536], BitVecSorts[1]
+                )
+                ret = ByteVec(uint256(f_ecpairing(arg)))
+
+            # blake2f
+            elif eq(to, con_addr(9)):
+                exit_code = con(1)
+                f_blake2f = Function(
+                    f"f_blake2f", BitVecSorts[1704], BitVecSorts[512]
+                )
+                ret = ByteVec(f_blake2f(arg))
+
+            # point_evaluation
+            elif eq(to, con_addr(10)):
+                exit_code = con(1)
+                f_point_evaluation = Function(
+                    f"f_point_evaluation", BitVecSorts[1544], BitVecSorts[512]
+                )
+                ret = ByteVec(f_point_evaluation(arg))
 
             # halmos cheat code
             elif eq(to, halmos_cheat_code.address):
@@ -1822,8 +1889,7 @@ class SEVM:
         # precompiles or cheatcodes
         if (
             # precompile
-            eq(to, con_addr(1))
-            or eq(to, con_addr(4))
+            (is_bv_value(to) and to.as_long() in range(1,11))
             # cheatcode calls
             or eq(to, halmos_cheat_code.address)
             or eq(to, hevm_cheat_code.address)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1552,7 +1552,7 @@ class SEVM:
                 debug(f"Potential empty address: {hexify(target)}")
             potential_aliases.append((None, emptyness_cond))
 
-        if len(potential_aliases) == 0:
+        if not potential_aliases:
             raise InfeasiblePath("resolve_address_alias: no potential aliases")
 
         if len(potential_aliases) > 1:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1663,7 +1663,12 @@ class SEVM:
         ex.balance_update(to, self.arith(ex, EVM.ADD, ex.balance_of(to), value))
 
     def call(
-        self, ex: Exec, op: int, to_alias: Address, stack: List[Tuple[Exec, int]], step_id: int
+        self,
+        ex: Exec,
+        op: int,
+        to_alias: Address,
+        stack: List[Tuple[Exec, int]],
+        step_id: int,
     ) -> None:
         # `to`: the original (symbolic) target address
         # `to_alias`: a (concrete) alias of the target considered in this path.

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2486,9 +2486,13 @@ class SEVM:
                         or eq(account, console.address)
                     ):
                         # dummy arbitrary value, consistent with foundry
-                        codehash = con(0xb0450508e5a2349057c3b4c9c84524d62be4bb17e565dbe2df34725a26872291) if eq(account, hevm_cheat_code.address) else ZERO
+                        codehash = (
+                            0xB0450508E5A2349057C3B4C9C84524D62BE4BB17E565DBE2DF34725A26872291
+                            if eq(account, hevm_cheat_code.address)
+                            else 0
+                        )
                     else:
-                        codehash = ZERO  # vs EMPTY_KECCAK, see EIP-1052
+                        codehash = 0  # vs EMPTY_KECCAK, see EIP-1052
 
                     ex.st.push(codehash)
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2412,7 +2412,7 @@ class SEVM:
                     account_code: Optional[Contract] = ex.code.get(addr, None)
 
                     codehash = (
-                        EMPTY_KECCAK
+                        con(0)
                         if account_code is None
                         else ex.sha3_data(account_code._code.unwrap())
                     )

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1251,30 +1251,12 @@ def is_power_of_two(x: int) -> bool:
 
 class HalmosLogs:
     bounded_loops: List[str]
-    unknown_calls: Dict[str, Dict[str, Set[str]]]  # funsig -> to -> set(arg)
 
     def __init__(self) -> None:
         self.bounded_loops = []
-        self.unknown_calls = defaultdict(lambda: defaultdict(set))
 
     def extend(self, logs: "HalmosLogs") -> None:
         self.bounded_loops.extend(logs.bounded_loops)
-        for funsig in logs.unknown_calls:
-            for to in logs.unknown_calls[funsig]:
-                self.unknown_calls[funsig][to].update(logs.unknown_calls[funsig][to])
-
-    def add_uninterpreted_unknown_call(self, funsig, to, arg):
-        funsig, to, arg = hexify(funsig), hexify(to), hexify(arg)
-        self.unknown_calls[funsig][to].add(arg)
-
-    def print_unknown_calls(self):
-        for funsig in self.unknown_calls:
-            print(f"{funsig}:")
-            for to in self.unknown_calls[funsig]:
-                print(f"- {to}:")
-                print(
-                    "\n".join([f"  - {arg}" for arg in self.unknown_calls[funsig][to]])
-                )
 
 
 @dataclass
@@ -1842,9 +1824,6 @@ class SEVM:
                 # in evm, calls to non-existing contracts always succeed with empty returndata
                 exit_code = con(1)
                 ret = ByteVec()
-
-                # TODO: use proper warning
-                self.logs.add_uninterpreted_unknown_call(extract_funsig(arg), to, arg)
 
             # push exit code
             exit_code_var = BitVec(f"call_exit_code_{ex.new_call_id():>02}", BitVecSort256)

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -184,6 +184,9 @@ def create_solver(logic="QF_AUFBV", ctx=None, timeout=0, max_memory=0):
     # QF_AUFBV: quantifier-free bitvector + array theory: https://smtlib.cs.uiowa.edu/logics.shtml
     solver = SolverFor(logic, ctx=ctx)
 
+    # reset any remaining solver states from the default context
+    solver.reset()
+
     # set timeout
     solver.set(timeout=timeout)
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -447,6 +447,11 @@ def stringify(symbol_name: str, val: Any):
         return hexify(val)
 
 
+def assert_bv(x) -> None:
+    if not is_bv(x):
+        raise ValueError(x)
+
+
 def assert_address(x: Word) -> None:
     if is_concrete(x):
         if not 0 <= int_of(x) < 2**160:

--- a/src/halmos/warnings.py
+++ b/src/halmos/warnings.py
@@ -26,7 +26,6 @@ COUNTEREXAMPLE_UNKNOWN = ErrorCode("counterexample-unknown")
 UNSUPPORTED_OPCODE = ErrorCode("unsupported-opcode")
 REVERT_ALL = ErrorCode("revert-all")
 LOOP_BOUND = ErrorCode("loop-bound")
-UNINTERPRETED_UNKNOWN_CALLS = ErrorCode("uninterpreted-unknown-calls")
 
 
 def warn_code(error_code: ErrorCode, msg: str):

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -869,18 +869,9 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_extcodehash_unknown_addr_eq_0()",
-                "exitcode": 1,
-                "num_models": 1,
-                "models": null,
-                "num_paths": null,
-                "time": null,
-                "num_bounded_loops": null
-            },
-            {
-                "name": "check_extcodehash_unknown_addr_noteq_0()",
-                "exitcode": 1,
-                "num_models": 1,
+                "name": "check_extcodehash_unknown_addr_empty()",
+                "exitcode": 0,
+                "num_models": 0,
                 "models": null,
                 "num_paths": null,
                 "time": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -191,6 +191,15 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodecopy_boundary()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/Byte.t.sol:ByteTest": [

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -3100,43 +3100,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_unknown_common_callbacks(address)",
-                "exitcode": 0,
-                "num_models": 0,
-                "models": null,
-                "num_paths": null,
-                "time": null,
-                "num_bounded_loops": null
-            },
-            {
-                "name": "check_unknown_not_allowed(address)",
-                "exitcode": 3,
-                "num_models": 0,
-                "models": null,
-                "num_paths": null,
-                "time": null,
-                "num_bounded_loops": null
-            },
-            {
                 "name": "check_unknown_retsize_0(address)",
-                "exitcode": 0,
-                "num_models": 0,
-                "models": null,
-                "num_paths": null,
-                "time": null,
-                "num_bounded_loops": null
-            },
-            {
-                "name": "check_unknown_retsize_64(address)",
-                "exitcode": 0,
-                "num_models": 0,
-                "models": null,
-                "num_paths": null,
-                "time": null,
-                "num_bounded_loops": null
-            },
-            {
-                "name": "check_unknown_retsize_default(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -869,6 +869,15 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_extcodehash_cheatcode()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_extcodehash_empty_contract()",
                 "exitcode": 0,
                 "num_models": 0,
@@ -896,6 +905,15 @@
                 "num_bounded_loops": null
             },
             {
+                "name": "check_extcodehash_precompiles(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_extcodehash_symbolic_address(address)",
                 "exitcode": 0,
                 "num_models": 0,
@@ -915,6 +933,15 @@
             },
             {
                 "name": "check_extcodehash_symbolic_address_not_empty(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodesize_cheatcode()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -860,7 +860,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_extcodehash_empty()",
+                "name": "check_extcodehash_empty_contract()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -878,7 +878,70 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_extcodehash_unknown_addr_empty()",
+                "name": "check_extcodehash_nonexisting_account()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodehash_symbolic_address(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodehash_symbolic_address_empty(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodehash_symbolic_address_not_empty(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodesize_precompiles(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodesize_symbolic_address(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodesize_symbolic_address_empty(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_extcodesize_symbolic_address_not_empty(address)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/regression/test/Buffers.t.sol
+++ b/tests/regression/test/Buffers.t.sol
@@ -46,17 +46,15 @@ contract BuffersTest is Test {
         assertNotEq(value, 0);
     }
 
-    // TODO: uncomment when we support extcodecopy
-    // function check_extcodecopy_boundary() public {
-    //     address target = address(this);
-    //     uint256 index = target.code.length - 16;
-    //     uint256 value;
-    //     assembly {
-    //         extcodecopy(target, 0, index, 32)
-    //         value := mload(0)
-    //     }
+    function check_extcodecopy_boundary() public {
+        address target = address(this);
+        uint256 index = target.code.length - 16;
+        uint256 value;
+        assembly {
+            extcodecopy(target, 0, index, 32)
+            value := mload(0)
+        }
 
-    //     console2.log("value:", value);
-    //     assertNotEq(value, 0);
-    // }
+        assertNotEq(value, 0);
+    }
 }

--- a/tests/regression/test/Extcodehash.t.sol
+++ b/tests/regression/test/Extcodehash.t.sol
@@ -118,4 +118,16 @@ contract ExtcodehashTest is Test, SymTest {
 
         assertEq(codehash, keccak256(code));
     }
+
+    function check_extcodesize_precompiles(address precompiled) external {
+        vm.assume(0 <= uint160(precompiled));
+        vm.assume(uint160(precompiled) <= 0xa);
+
+        uint256 size;
+        assembly {
+            size := extcodesize(precompiled)
+        }
+
+        assertEq(size, 0);
+    }
 }

--- a/tests/regression/test/Extcodehash.t.sol
+++ b/tests/regression/test/Extcodehash.t.sol
@@ -228,7 +228,7 @@ contract ExtcodehashTest is Test, SymTest {
     }
 
     function check_extcodesize_precompiles(address precompiled) external {
-        vm.assume(0 <= uint160(precompiled));
+        vm.assume(1 <= uint160(precompiled));
         vm.assume(uint160(precompiled) <= 0xa);
 
         uint256 size;
@@ -237,5 +237,33 @@ contract ExtcodehashTest is Test, SymTest {
         }
 
         assertEq(size, 0);
+    }
+
+    function check_extcodehash_precompiles(address precompiled) external {
+        vm.assume(1 <= uint160(precompiled));
+        vm.assume(uint160(precompiled) <= 0xa);
+
+        uint256 codehash;
+        assembly {
+            codehash := extcodehash(precompiled)
+        }
+
+        assertEq(codehash, 0);
+    }
+
+    function check_extcodesize_cheatcode() external {
+        assertEq(VM_ADDRESS, address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D));
+        assertEq(console.CONSOLE_ADDRESS, address(0x000000000000000000636F6e736F6c652e6c6f67));
+        assertEq(SymTest.SVM_ADDRESS, address(0xF3993A62377BCd56AE39D773740A5390411E8BC9));
+
+        assertEq(VM_ADDRESS.code.length, 1);
+        assertEq(console.CONSOLE_ADDRESS.code.length, 0);
+        assertEq(SymTest.SVM_ADDRESS.code.length, 0);
+    }
+
+    function check_extcodehash_cheatcode() external {
+        assertEq(VM_ADDRESS.codehash, 0xb0450508e5a2349057c3b4c9c84524d62be4bb17e565dbe2df34725a26872291);
+        assertEq(console.CONSOLE_ADDRESS.codehash, 0);
+        assertEq(SymTest.SVM_ADDRESS.codehash, 0);
     }
 }

--- a/tests/regression/test/Extcodehash.t.sol
+++ b/tests/regression/test/Extcodehash.t.sol
@@ -89,11 +89,14 @@ contract ExtcodehashTest is Test, SymTest {
         assertEq(emptyCodeAddr.code.length, 0, "Empty contract should have no code");
 
         bytes32 codehash;
+        bytes32 nextCodehash;
         assembly {
             codehash := extcodehash(emptyCodeAddr)
+            nextCodehash := extcodehash(add(emptyCodeAddr, 1))
         }
 
         assertEq(codehash, keccak256(""), "Expected codehash of the empty string");
+        assertEq(nextCodehash, 0, "Expected 0");
     }
 
     /// unknown addresses are assumed to be non-existing, thus have no code

--- a/tests/regression/test/Extcodehash.t.sol
+++ b/tests/regression/test/Extcodehash.t.sol
@@ -96,26 +96,14 @@ contract ExtcodehashTest is Test, SymTest {
         assertEq(codehash, keccak256(""), "Expected codehash of the empty string");
     }
 
-    /// yields a path where it is eq to 0, and a path where it is not
-    /// so we expect a counterexample for this and also its negation
-    function check_extcodehash_unknown_addr_eq_0() external {
+    /// unknown addresses are assumed to be non-existing, thus have no code
+    function check_extcodehash_unknown_addr_empty() external {
         bytes32 codehash;
         assembly {
             codehash := extcodehash(0x1337)
         }
 
-        assertEq(codehash, 0);
-    }
-
-    /// yields a path where it is eq to 0, and a path where it is not
-    /// so we expect a counterexample for this and also its negation
-    function check_extcodehash_unknown_addr_noteq_0()   external {
-        bytes32 codehash;
-        assembly {
-            codehash := extcodehash(0x1337)
-        }
-
-        assertNotEq(codehash, 0);
+        assertEq(codehash, keccak256(""), "Expected codehash of the empty string");
     }
 
     function check_extcodehash_after_etch() external {

--- a/tests/regression/test/HalmosCheatCode.t.sol
+++ b/tests/regression/test/HalmosCheatCode.t.sol
@@ -109,7 +109,11 @@ contract HalmosCheatCodeTest is SymTest, Test {
     }
 
     function check_FailUnknownCheatcode() public {
-        Dummy(address(svm)).foo(); // expected to fail with unknown cheatcode
+        // expected to fail with unknown cheatcode
+        address(svm).call(abi.encodeWithSelector(Dummy.foo.selector));
+
+        // NOTE: the following reverts due to the failure of the nonzero check for extcodesize(svm)
+        // Dummy(address(svm)).foo();
     }
 }
 

--- a/tests/regression/test/UnknownCall.t.sol
+++ b/tests/regression/test/UnknownCall.t.sol
@@ -50,6 +50,9 @@ contract UnknownCallTest is Test {
             assert(addr.balance == amount);
             assert(address(this).balance == initial - amount);
         } else {
+            // NOTE: currently this branch is not reachable, because the balance is implicitly assumed to be enough
+            // TODO: fix halmos to consider the case where the balance is not enough
+            assert(false);
             assert(addr.balance == 0);
             assert(address(this).balance == initial);
         }


### PR DESCRIPTION
When a call target address may be aliased with multiple existing addresses, or may be non-existent, explicitly branching into multiple paths for each potential alias or non-existent address.

Although this change may increase the number of potential paths, it eliminates the time needed to solve must-alias conditions, which can take up to 1s each. Also, the path branching is unlikely to exponentially grow, unless there are many duplicated instances of contracts with similar interfaces, because most paths will immediately revert due to unimplemented selectors. In such cases, the time saved by reducing solver overhead outweighs the cost of increased path branching.

As a result, "unknown calls" no longer exist, and the related options, `--uninterpreted-unknown-calls` and `--return-size-of-unknown-calls`, are no longer needed and have been deprecated.