### PR TITLE
ci: use temp forked repo for updated tests

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -26,6 +26,12 @@ jobs:
         #   cmd: "--function testProve --loop 4
         #   branch: ""
         #   profile: ""
+          # temporary forked repo with updated tests
+          - repo: "daejunpark/morpho-data-structures"
+            dir: "morpho-data-structures"
+            cmd: "--function testProve --loop 4
+            branch: "ci/halmos"
+            profile: ""
           - repo: "a16z/cicada"
             dir: "cicada"
             cmd: "--contract LibUint1024Test --function testProve --loop 256"

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -23,13 +23,13 @@ jobs:
         # TODO: enable after migrating morpho-data-structures tests to use new cheatcode instead of --symbolic-storage
         # - repo: "morpho-org/morpho-data-structures"
         #   dir: "morpho-data-structures"
-        #   cmd: "--function testProve --loop 4
+        #   cmd: "--function testProve --loop 4"
         #   branch: ""
         #   profile: ""
-          # temporary forked repo with updated tests
+        # temporary forked repo with updated tests
           - repo: "daejunpark/morpho-data-structures"
             dir: "morpho-data-structures"
-            cmd: "--function testProve --loop 4
+            cmd: "--function testProve --loop 4"
             branch: "ci/halmos"
             profile: ""
           - repo: "a16z/cicada"


### PR DESCRIPTION
a temporary forked repo is used for morpho tests. the morpho tests in the forked repo have been updated to avoid --symbolic-storage, and use enableSymbolicStorage() cheatcode instead.

the temporary use of the forked repo is unavoidable, because the changes in the fork cannot be upstreamed until the next version of halmos is released. after the release, we can upstream the changes and revert to using the main repo.