### PR TITLE
fix: concretize calldatacopy

### DIFF
--- a/src/halmos/bytevec.py
+++ b/src/halmos/bytevec.py
@@ -613,7 +613,7 @@ class ByteVec:
 
     def concretize(self, substitution: dict[BitVecRef, BitVecRef]) -> None:
         """
-        Replace all symbols in the chunks with their corresponding concrete values, if they exist in the given substituion mapping.
+        Replace all symbols in the chunks with their corresponding concrete values, if they exist in the given substitution mapping.
         """
         for offset, chunk in self.chunks.items():
             chunk_data = chunk.data

--- a/src/halmos/bytevec.py
+++ b/src/halmos/bytevec.py
@@ -613,7 +613,10 @@ class ByteVec:
 
     def concretize(self, substitution: dict[BitVecRef, BitVecRef]) -> None:
         """
-        Replace all symbols in the chunks with their corresponding concrete values, if they exist in the given substitution mapping.
+        Replace all top-level symbols in the chunks with their corresponding concrete values, if they exist in the given substitution mapping.
+
+        Note: only top-level symbols are currently replaced, not those within nested symbolic terms.
+        This approach is sufficient for current calldata use cases. Performance impacts should be evaluated if all symbol occurrences need to be replaced.
         """
         for offset, chunk in self.chunks.items():
             chunk_data = chunk.data

--- a/src/halmos/bytevec.py
+++ b/src/halmos/bytevec.py
@@ -5,7 +5,6 @@ from typing import Any, ForwardRef
 
 from sortedcontainers import SortedDict
 from z3 import BitVecRef, If, eq, is_bool, is_bv, is_bv_value, simplify, substitute
-from z3.z3util import is_expr_var
 
 from .utils import (
     Byte,
@@ -165,9 +164,7 @@ class Chunk(ABC):
         new_data = simplify(new_data)
 
         return (
-            ConcreteChunk(
-                bv_value_to_bytes(new_data), self.start, self.length
-            )
+            ConcreteChunk(bv_value_to_bytes(new_data), self.start, self.length)
             if is_bv_value(new_data)
             else SymbolicChunk(new_data, self.start, self.length)
         )

--- a/src/halmos/calldata.py
+++ b/src/halmos/calldata.py
@@ -103,19 +103,10 @@ class FunctionInfo:
 
 
 class Calldata:
-    args: HalmosConfig
-
-    # `arrlen` holds the parsed value of --array-lengths, specifying the sizes for certain dynamic parameters.
-    # `default_bytes_lengths` holds the parsed value of --default-bytes-lengths.
-    #
     # For dynamic parameters not explicitly listed in --array-lengths, default sizes are used:
     # - For dynamic arrays: the size ranges from 0 to the value of --loop (inclusive).
     # - For bytes or strings: the size candidates are given by --default-bytes-lengths.
-    #
-    # TODO: Extend `args` to include `arrlen` and `default_bytes_lengths`
-    #       to prevent re-parsing --array-lengths and --default-bytes-lengths multiple times.
-    arrlen: dict[str, list[int]]
-    default_bytes_lengths: list[int]
+    args: HalmosConfig
 
     # `dyn_params` will be updated to include the fully resolved size information for all dynamic parameters.
     dyn_params: list[DynamicParam]
@@ -130,10 +121,6 @@ class Calldata:
         new_symbol_id: Callable | None,
     ) -> None:
         self.args = args
-        self.arrlen = mk_arrlen(args)
-        self.default_bytes_lengths = [
-            int(x.strip()) for x in self.args.default_bytes_lengths.split(",")
-        ]
         self.dyn_params = []
         self.new_symbol_id = new_symbol_id if new_symbol_id else lambda: ""
 
@@ -144,13 +131,13 @@ class Calldata:
         The candidates are derived from --array_lengths if provided; otherwise, default values are used.
         """
 
-        sizes = self.arrlen.get(name)
+        sizes = self.args.array_lengths.get(name)
 
         if sizes is None:
             sizes = (
                 list(range(self.args.loop + 1))
                 if isinstance(typ, DynamicArrayType)
-                else self.default_bytes_lengths  # bytes or string
+                else self.args.default_bytes_lengths  # bytes or string
             )
             if self.args.debug:
                 print(
@@ -345,15 +332,3 @@ def mk_calldata(
     new_symbol_id: Callable = None,
 ) -> tuple[ByteVec, list[DynamicParam]]:
     return Calldata(args, new_symbol_id).create(abi, fun_info)
-
-
-def mk_arrlen(args: HalmosConfig) -> dict[str, list[int]]:
-    if not args.array_lengths:
-        return {}
-
-    # TODO: update syntax: name1=size1,size2; name2=size3,...; ...
-    name_sizes_pairs = args.array_lengths.split(",")
-    return {
-        name.strip(): [int(x.strip()) for x in sizes.split(";")]
-        for name, sizes in [x.split("=") for x in name_sizes_pairs]
-    }

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -551,7 +551,9 @@ class TomlParser:
 
         # gather custom actions
         actions = {
-            field.name: field.metadata["action"] for field in fields(Config) if "action" in field.metadata
+            field.name: field.metadata["action"]
+            for field in fields(Config)
+            if "action" in field.metadata
         }
 
         result = {}

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -551,7 +551,7 @@ class TomlParser:
 
         # gather custom actions
         actions = {
-            field.name: field.metadata.get("action", None) for field in fields(Config)
+            field.name: field.metadata["action"] for field in fields(Config) if "action" in field.metadata
         }
 
         result = {}

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -549,15 +549,17 @@ class TomlParser:
                 )
                 sys.exit(2)
 
-        def parse_value(k, v):
-            if k == "default-bytes-lengths":
-                return ParseCSV.parse(v)
-            elif k == "array-lengths":
-                return ParseArrayLengths.parse(v)
-            else:
-                return v
+        # gather custom actions
+        actions = {
+            field.name: field.metadata.get("action", None) for field in fields(Config)
+        }
 
-        return {k.replace("-", "_"): parse_value(k, v) for k, v in data.items()}
+        result = {}
+        for key, value in data.items():
+            key = key.replace("-", "_")
+            action = actions.get(key)
+            result[key] = action.parse(value) if action else value
+        return result
 
 
 def _create_default_config() -> "Config":

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -549,7 +549,15 @@ class TomlParser:
                 )
                 sys.exit(2)
 
-        return {k.replace("-", "_"): v for k, v in data.items()}
+        def parse_value(k, v):
+            if k == "default-bytes-lengths":
+                return ParseCSV.parse(v)
+            elif k == "array-lengths":
+                return ParseArrayLengths.parse(v)
+            else:
+                return v
+
+        return {k.replace("-", "_"): parse_value(k, v) for k, v in data.items()}
 
 
 def _create_default_config() -> "Config":

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import MISSING, dataclass, fields
 from dataclasses import field as dataclass_field
 from typing import Any
@@ -33,6 +34,7 @@ def arg(
     short: str | None = None,
     countable: bool = False,
     global_default_str: str | None = None,
+    action: Callable = None,
 ):
     return dataclass_field(
         default=None,
@@ -45,8 +47,37 @@ def arg(
             "short": short,
             "countable": countable,
             "global_default_str": global_default_str,
+            "action": action,
         },
     )
+
+
+class ParseCSV(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        values = ParseCSV.parse(values)
+        setattr(namespace, self.dest, values)
+
+    @staticmethod
+    def parse(values: str) -> list[int]:
+        return [int(x.strip()) for x in values.split(",")]
+
+
+class ParseArrayLengths(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        values = ParseArrayLengths.parse(values)
+        setattr(namespace, self.dest, values)
+
+    @staticmethod
+    def parse(values: str | None) -> dict[str, list[int]]:
+        if not values:
+            return {}
+
+        # TODO: update syntax: name1=size1,size2; name2=size3,...; ...
+        name_sizes_pairs = values.split(",")
+        return {
+            name.strip(): [int(x.strip()) for x in sizes.split(";")]
+            for name, sizes in [x.split("=") for x in name_sizes_pairs]
+        }
 
 
 # TODO: add kw_only=True when we support Python>=3.10
@@ -152,12 +183,14 @@ class Config:
         help="set the length of dynamic-sized arrays including bytes and string (default: loop unrolling bound)",
         global_default=None,
         metavar="NAME1=LENGTH1,NAME2=LENGTH2,...",
+        action=ParseArrayLengths,
     )
 
     default_bytes_lengths: str = arg(
         help="set the default length candidates for bytes and string not specified in --array-lengths",
         global_default="0,32,1024,65",  # 65 is ECDSA signature size
         metavar="LENGTH1,LENGTH2,...",
+        action=ParseCSV,
     )
 
     storage_layout: str = arg(
@@ -528,7 +561,12 @@ def _create_default_config() -> "Config":
         if default == MISSING:
             continue
 
-        values[field.name] = default() if callable(default) else default
+        # retrieve the default value
+        raw_value = default() if callable(default) else default
+
+        # parse the default value, if a custom parser is provided
+        action = field.metadata.get("action", None)
+        values[field.name] = action.parse(raw_value) if action else raw_value
 
     return Config(_parent=None, _source="default", **values)
 
@@ -583,6 +621,8 @@ def _create_arg_parser() -> argparse.ArgumentParser:
             }
             if choices := field_info.metadata.get("choices", None):
                 kwargs["choices"] = choices
+            if action := field_info.metadata.get("action", None):
+                kwargs["action"] = action
             group.add_argument(*names, **kwargs)
 
     return parser

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -644,8 +644,10 @@ class Concretization:
     In the future, it may be used for other purposes, such as concrete hash reasoning.
     """
 
-    substitution: dict = field(default_factory=dict)  # symbol -> constant
-    candidates: dict = field(default_factory=dict)  # symbol -> set of constants
+    # symbol -> constant
+    substitution: dict[BitVecRef, BitVecRef] = field(default_factory=dict)
+    # symbol -> set of constants
+    candidates: dict[BitVecRef, list[int]] = field(default_factory=dict)
 
     def process_cond(self, cond):
         if not is_eq(cond):
@@ -2863,6 +2865,7 @@ class SEVM:
 
                     if size > 0:
                         data: ByteVec = ex.calldata().slice(offset, offset + size)
+                        data.concretize(ex.path.concretization.substitution)
                         ex.st.memory.set_slice(loc, end_loc, data)
 
                 elif opcode == EVM.CODECOPY:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2866,7 +2866,7 @@ class SEVM:
 
                     if size > 0:
                         data: ByteVec = ex.calldata().slice(offset, offset + size)
-                        data.concretize(ex.path.concretization.substitution)
+                        data = data.concretize(ex.path.concretization.substitution)
                         ex.st.memory.set_slice(loc, end_loc, data)
 
                 elif opcode == EVM.CODECOPY:


### PR DESCRIPTION
there are two instructions that read calldata, and their concretization logic works as follows:
- calldataload: concretizes symbols if they exist in either the substitution or candidates mapping. it may cause the current path to branch.
- calldatacopy: concretizes symbols only if they exist in the substitution mapping. no path branching.

this behavior is based on typical calldata decoding logic, where the length of dynamic arguments is first read using calldataload, and their data is then read using either calldataload or calldatacopy.