### PR TITLE
feat: target Panic(k) for any k specified in --panic-error-codes

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -667,10 +667,11 @@ def run(
 
         output = ex.context.output
         error_output = output.error
-        if ex.reverted_with_panic(args.panic_error_codes) or is_global_fail_set(ex.context):
+        if ex.is_panic_of(args.panic_error_codes) or is_global_fail_set(ex.context):
             if args.verbose >= 1:
                 print(f"Found potential path (id: {idx+1})")
-                print(f"Panic(0x{unbox_int(output.data[4:36].unwrap()):02x}) {error_output}")
+                panic_code = unbox_int(output.data[4:36].unwrap())
+                print(f"Panic(0x{panic_code:02x}) {error_output}")
 
             if args.verbose >= VERBOSITY_TRACE_COUNTEREXAMPLE:
                 traces[idx] = rendered_trace(ex.context)

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -108,14 +108,6 @@ sys.setrecursionlimit(1024 * 4)
 if sys.stdout.encoding != "utf-8":
     sys.stdout.reconfigure(encoding="utf-8")
 
-# Panic(1)
-# bytes4(keccak256("Panic(uint256)")) + bytes32(1)
-ASSERT_FAIL = ByteVec(
-    bytes.fromhex(
-        "4E487B710000000000000000000000000000000000000000000000000000000000000001"
-    )
-)
-
 VERBOSITY_TRACE_COUNTEREXAMPLE = 2
 VERBOSITY_TRACE_SETUP = 3
 VERBOSITY_TRACE_PATHS = 4
@@ -673,11 +665,12 @@ def run(
             print("\nTrace:")
             render_trace(ex.context)
 
-        error_output = ex.context.output.error
-        if ex.reverted_with(ASSERT_FAIL) or is_global_fail_set(ex.context):
+        output = ex.context.output
+        error_output = output.error
+        if ex.reverted_with_panic(args.panic_error_codes) or is_global_fail_set(ex.context):
             if args.verbose >= 1:
                 print(f"Found potential path (id: {idx+1})")
-                print(f"{error_output}")
+                print(f"Panic(0x{unbox_int(output.data[4:36].unwrap()):02x}) {error_output}")
 
             if args.verbose >= VERBOSITY_TRACE_COUNTEREXAMPLE:
                 traces[idx] = rendered_trace(ex.context)

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -62,6 +62,22 @@ class ParseCSV(argparse.Action):
         return [int(x.strip()) for x in values.split(",")]
 
 
+class ParseErrorCodes(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        values = ParseErrorCodes.parse(values)
+        setattr(namespace, self.dest, values)
+
+    @staticmethod
+    def parse(values: str) -> set[int]:
+        values = values.strip()
+        # return empty set, which will be interpreted as matching any value in Exec.reverted_with_panic()
+        if values == "*":
+            return set()
+
+        # support multiple bases: decimal, hex, etc.
+        return set(int(x.strip(), 0) for x in values.split(","))
+
+
 class ParseArrayLengths(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         values = ParseArrayLengths.parse(values)
@@ -159,6 +175,13 @@ class Config:
         global_default="",
         metavar="FUNCTION_NAME_REGEX",
         short="mt",
+    )
+
+    panic_error_codes: str = arg(
+        help="specify Panic error codes to be treated as test failures; use '*' to include all error codes",
+        global_default="0x01",
+        metavar="ERROR_CODE1,ERROR_CODE2,...",
+        action=ParseErrorCodes,
     )
 
     loop: int = arg(

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -132,7 +132,7 @@ ZERO, ONE = con(0), con(1)
 MAX_CALL_DEPTH = 1024
 
 # bytes4(keccak256("Panic(uint256)"))
-PANIC_SELECTOR = ByteVec(bytes.fromhex("4E487B71"))
+PANIC_SELECTOR = bytes.fromhex("4E487B71")
 
 EMPTY_BALANCE = Array("balance_00", BitVecSort160, BitVecSort256)
 
@@ -924,7 +924,7 @@ class Exec:  # an execution path
         if byte_length(error_data) != 36:
             return False
 
-        error_selector = error_data[0:4]
+        error_selector = error_data[0:4].unwrap()
         if error_selector != PANIC_SELECTOR:
             return False
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -906,7 +906,7 @@ class Exec:  # an execution path
     def is_halted(self) -> bool:
         return self.context.output.data is not None
 
-    def reverted_with_panic(self, expected_error_codes: set[int]) -> bool:
+    def is_panic_of(self, expected_error_codes: set[int]) -> bool:
         """
         Check if the error is Panic(k) for any k in the given error code set.
         An empty set or None will match any error code.

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -131,6 +131,9 @@ EMPTY_KECCAK = con(0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D8
 ZERO, ONE = con(0), con(1)
 MAX_CALL_DEPTH = 1024
 
+# bytes4(keccak256("Panic(uint256)"))
+PANIC_SELECTOR = ByteVec(bytes.fromhex("4E487B71"))
+
 EMPTY_BALANCE = Array("balance_00", BitVecSort160, BitVecSort256)
 
 # TODO: make this configurable
@@ -903,14 +906,35 @@ class Exec:  # an execution path
     def is_halted(self) -> bool:
         return self.context.output.data is not None
 
-    def reverted_with(self, expected: ByteVec) -> bool:
-        if not isinstance(self.context.output.error, Revert):
+    def reverted_with_panic(self, expected_error_codes: set[int]) -> bool:
+        """
+        Check if the error is Panic(k) for any k in the given error code set.
+        An empty set or None will match any error code.
+
+        Panic(k) is encoded as 36 bytes (4 + 32) consisting of:
+            bytes4(keccak256("Panic(uint256)")) + bytes32(k)
+        """
+
+        output = self.context.output
+
+        if not isinstance(output.error, Revert):
             return False
 
-        returndata = self.context.output.data[: byte_length(expected)]
+        error_data = output.data
+        if byte_length(error_data) != 36:
+            return False
 
-        # bytevec equality check, will take care of length check, bv vs symbolic, etc.
-        return returndata == expected
+        error_selector = error_data[0:4]
+        if error_selector != PANIC_SELECTOR:
+            return False
+
+        # match any error code
+        if not expected_error_codes:
+            return True
+
+        # the argument of Panic is expected to be concrete
+        error_code = unbox_int(error_data[4:36].unwrap())
+        return error_code in expected_error_codes
 
     def emit_log(self, log: EventLog):
         self.context.trace.append(log)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -933,6 +933,7 @@ class Exec:  # an execution path
             return True
 
         # the argument of Panic is expected to be concrete
+        # NOTE: symbolic error code will be silently ignored
         error_code = unbox_int(error_data[4:36].unwrap())
         return error_code in expected_error_codes
 

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1771,6 +1771,116 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/Panic.t.sol:PanicTest": [
+            {
+                "name": "check_panic_0_fail(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_0_pass(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_11_fail(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_11_pass(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_12_fail(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_12_pass(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_1_fail(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_1_pass(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_2_or_3_fail_2(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_2_or_3_fail_3(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_5_fail_old(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_any_fail_4(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/Prank.t.sol:PrankSetUpTest": [
             {
                 "name": "check_prank(address)",

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1791,7 +1791,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_panic_11_fail(uint256)",
+                "name": "check_panic_0x11_fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "models": null,
@@ -1800,7 +1800,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_panic_11_pass(uint256)",
+                "name": "check_panic_0x11_pass(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1809,7 +1809,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_panic_12_fail(uint256)",
+                "name": "check_panic_0x12_fail(uint256)",
                 "exitcode": 1,
                 "num_models": 1,
                 "models": null,
@@ -1818,9 +1818,27 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_panic_12_pass(uint256)",
+                "name": "check_panic_0x12_pass(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_10_fail(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_16_fail(bool)",
+                "exitcode": 1,
+                "num_models": 1,
                 "models": null,
                 "num_paths": null,
                 "time": null,
@@ -1864,6 +1882,24 @@
             },
             {
                 "name": "check_panic_5_fail_old(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_7_fail(bool)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_8_fail(bool)",
                 "exitcode": 1,
                 "num_models": 1,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1915,6 +1915,60 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_inc_assert_fail(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_inc_assert_pass(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_inc_cheatcode_fail(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_inc_fail(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_inc_overflow_fail(uint256)",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_panic_inc_overflow_pass(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/Prank.t.sol:PrankSetUpTest": [

--- a/tests/regression/halmos.toml
+++ b/tests/regression/halmos.toml
@@ -24,6 +24,9 @@ function = "check_"
 # The --function prefix is automatically added, unless the regex starts with '^'.
 match-test = ""
 
+# specify Panic error codes to be treated as test failures; use '*' to include all error codes
+panic-error-codes = "0x01"
+
 # set loop unrolling bounds
 loop = 2
 
@@ -34,7 +37,7 @@ width = 0
 depth = 0
 
 # set the length of dynamic-sized arrays including bytes and string (default: loop unrolling bound)
-# array-lengths = NAME1=LENGTH1,NAME2=LENGTH2,...
+array-lengths = ""
 
 # set the default length candidates for bytes and string not specified in --array-lengths
 default-bytes-lengths = "0,1024,65"

--- a/tests/regression/test/Panic.t.sol
+++ b/tests/regression/test/Panic.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+/*
+ *  Panic error code:
+ *  https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require
+ *  - 0x00: Used for generic compiler inserted panics.
+ *  - 0x01: If you call assert with an argument that evaluates to false.
+ *  - 0x11: If an arithmetic operation results in underflow or overflow outside of an unchecked { ... } block.
+ *  - 0x12; If you divide or modulo by zero (e.g. 5 / 0 or 23 % 0).
+ *  - 0x21: If you convert a value that is too big or negative into an enum type.
+ *  - 0x22: If you access a storage byte array that is incorrectly encoded.
+ *  - 0x31: If you call .pop() on an empty array.
+ *  - 0x32: If you access an array, bytesN or an array slice at an out-of-bounds or negative index (i.e. x[i] where i >= x.length or i < 0).
+ *  - 0x41: If you allocate too much memory or create an array that is too large.
+ *  - 0x51: If you call a zero-initialized variable of internal function type.
+ */
+
+contract PanicTest is Test {
+    function _panic(uint code) internal pure {
+        // revert Panic(code);
+        bytes memory data = abi.encodeWithSignature("Panic(uint256)", code);
+        assembly {
+            revert(add(data, 0x20), mload(data))
+        }
+    }
+
+    function _panic_old_compiler(uint code) internal pure {
+        assembly {
+            mstore(0x00, 0x4e487b71)
+            mstore(0x20, code)
+            revert(0x1c, 0x24)
+        }
+    }
+
+    /// @custom:halmos --panic-error-codes 0x00
+    function check_panic_0_fail(bool x) public {
+        if (x) _panic(0);
+    }
+
+    function check_panic_0_pass(bool x) public {
+        if (x) _panic(0); // not treated as failure because the default error code is 1
+    }
+
+    function check_panic_1_fail(bool x) public {
+        if (x) _panic(1); // default error code is 1
+    }
+
+    /// @custom:halmos --panic-error-codes 0x00
+    function check_panic_1_pass(bool x) public {
+        if (x) _panic(1);
+    }
+
+    /// @custom:halmos --panic-error-codes 0x02,0x03
+    function check_panic_2_or_3_fail_2(bool x) public {
+        if (x) _panic(2);
+    }
+
+    /// @custom:halmos --panic-error-codes 0x02,0x03
+    function check_panic_2_or_3_fail_3(bool x) public {
+        if (x) _panic(3);
+    }
+
+    /// @custom:halmos --panic-error-codes *
+    function check_panic_any_fail_4(bool x) public {
+        if (x) _panic(4);
+    }
+
+    /// @custom:halmos --panic-error-codes 0x05
+    function check_panic_5_fail_old(bool x) public {
+        if (x) _panic_old_compiler(5);
+    }
+
+    /// @custom:halmos --panic-error-codes 0x11
+    function check_panic_11_fail(uint x) public returns (uint) {
+        // 0x11: overflow
+        return x + 1; // counterexample: x == 2^256 - 1
+    }
+
+    function check_panic_11_pass(uint x) public returns (uint) {
+        return x + 1;
+    }
+
+    /// @custom:halmos --panic-error-codes 0x12
+    function check_panic_12_fail(uint x) public returns (uint) {
+        // 0x12: div-by-zero
+        return 10 / x; // counterexample: x == 0
+    }
+
+    function check_panic_12_pass(uint x) public returns (uint) {
+        return 10 / x;
+    }
+}

--- a/tests/regression/test/Panic.t.sol
+++ b/tests/regression/test/Panic.t.sol
@@ -53,6 +53,10 @@ contract PanicTest is Test {
         if (x) _panic(1);
     }
 
+    //
+    // multiple error codes
+    //
+
     /// @custom:halmos --panic-error-codes 0x02,0x03
     function check_panic_2_or_3_fail_2(bool x) public {
         if (x) _panic(2);
@@ -68,28 +72,64 @@ contract PanicTest is Test {
         if (x) _panic(4);
     }
 
+    //
+    // old compiler revert
+    //
+
     /// @custom:halmos --panic-error-codes 0x05
     function check_panic_5_fail_old(bool x) public {
         if (x) _panic_old_compiler(5);
     }
 
+    //
+    // numeric literal bases
+    //
+
+    // binary
+    /// @custom:halmos --panic-error-codes 0b111
+    function check_panic_7_fail(bool x) public {
+        if (x) _panic(7);
+    }
+
+    // octal
+    /// @custom:halmos --panic-error-codes 0o10
+    function check_panic_8_fail(bool x) public {
+        if (x) _panic(8);
+    }
+
+    // decimal
+    /// @custom:halmos --panic-error-codes 10
+    function check_panic_10_fail(bool x) public {
+        if (x) _panic(10);
+    }
+
+    // hex
+    /// @custom:halmos --panic-error-codes 0x10
+    function check_panic_16_fail(bool x) public {
+        if (x) _panic(16);
+    }
+
+    //
+    // panic error code semantics
+    //
+
     /// @custom:halmos --panic-error-codes 0x11
-    function check_panic_11_fail(uint x) public returns (uint) {
+    function check_panic_0x11_fail(uint x) public returns (uint) {
         // 0x11: overflow
         return x + 1; // counterexample: x == 2^256 - 1
     }
 
-    function check_panic_11_pass(uint x) public returns (uint) {
+    function check_panic_0x11_pass(uint x) public returns (uint) {
         return x + 1;
     }
 
     /// @custom:halmos --panic-error-codes 0x12
-    function check_panic_12_fail(uint x) public returns (uint) {
+    function check_panic_0x12_fail(uint x) public returns (uint) {
         // 0x12: div-by-zero
         return 10 / x; // counterexample: x == 0
     }
 
-    function check_panic_12_pass(uint x) public returns (uint) {
+    function check_panic_0x12_pass(uint x) public returns (uint) {
         return 10 / x;
     }
 }


### PR DESCRIPTION
Previously, only Panic(1) was treated as a test failure that triggered counterexample generation, meaning other types of reverts were silently ignored. This made sense because we were focused on detecting assertion failures in test contracts. However, there are cases where we'd like to ensure that not only assertion failures but also other types of reverts (e.g., arithmetic overflows) do not occur.

Now, Panic(k) for any arbitrary k specified using the new `--panic-error-codes` flag is treated as a test failure. The default value for this flag is 1, maintaining the previous default behavior.

The flag takes a list of error codes (in either decimal or hex format.) To match any integer k, you can use `--panic-error-codes *`.

--

For example, the following test will fail with a counterexample due to overflow:
```
    /// @custom:halmos --panic-error-codes 0x11
    function check_panic_0x11_fail(uint x) public returns (uint) {
        // 0x11: overflow
        return x + 1; // counterexample: x == 2^256 - 1
    }
```
See [`tests/regression/test/Panic.t.sol`](https://github.com/a16z/halmos/blob/main/tests/regression/test/Panic.t.sol) for more examples.