### PR TITLE
fix: unparse config value to generate toml file

### DIFF
--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -59,7 +59,7 @@ def ensure_non_empty(values: list | set | dict, raw_values: str) -> list:
 
 
 def parse_csv(values: str, sep: str = ",") -> Generator[Any, None, None]:
-    """Parse a CSV string and return a generator of values."""
+    """Parse a CSV string and return a generator of *non-empty* values."""
     return (x for _x in values.split(sep) if (x := _x.strip()))
 
 
@@ -112,7 +112,7 @@ class ParseArrayLengths(argparse.Action):
         # TODO: update syntax: name1={size1,size2},name2=size3,...
         return {
             name.strip(): ensure_non_empty(
-                [int(x) for x in parse_csv(sizes, sep=";")], values
+                [int(x) for x in parse_csv(sizes, sep=";")], sizes
             )
             for name, sizes in (x.split("=") for x in parse_csv(values))
         }

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -2,10 +2,10 @@ import argparse
 import os
 import sys
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from dataclasses import MISSING, dataclass, fields
 from dataclasses import field as dataclass_field
-from typing import Any, Generator
+from typing import Any
 
 import toml
 
@@ -111,7 +111,9 @@ class ParseArrayLengths(argparse.Action):
 
         # TODO: update syntax: name1={size1,size2},name2=size3,...
         return {
-            name.strip(): ensure_non_empty([int(x) for x in parse_csv(sizes, sep=";")], values)
+            name.strip(): ensure_non_empty(
+                [int(x) for x in parse_csv(sizes, sep=";")], values
+            )
             for name, sizes in (x.split("=") for x in parse_csv(values))
         }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -258,6 +258,10 @@ def test_parse_error_codes_roundtrip():
 
 
 def test_parse_array_lengths():
+    with pytest.raises(ValueError):
+        ParseArrayLengths.parse("x=")
+        ParseArrayLengths.parse("x= ")
+        ParseArrayLengths.parse("x=;")
     assert ParseArrayLengths.parse("") == {}
     assert ParseArrayLengths.parse(" ") == {}
     assert ParseArrayLengths.parse(",") == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,9 @@ import pytest
 
 from halmos.config import (
     Config,
+    ParseArrayLengths,
+    ParseCSV,
+    ParseErrorCodes,
     arg_parser,
     default_config,
     resolve_config_files,
@@ -13,7 +16,7 @@ from halmos.config import (
 from halmos.config import (
     toml_parser as get_toml_parser,
 )
-from halmos.config import ParseCSV, ParseErrorCodes, ParseArrayLengths
+
 
 @pytest.fixture
 def config():
@@ -274,13 +277,19 @@ def test_parse_array_lengths():
     assert ParseArrayLengths.parse("x=1;2;,y=3;,") == {"x": [1, 2], "y": [3]}
     assert ParseArrayLengths.parse(" x = 1 ; 2 , y = 3 ") == {"x": [1, 2], "y": [3]}
     assert ParseArrayLengths.parse(" , x = 1 ; 2 , y = 3 , ") == {"x": [1, 2], "y": [3]}
-    assert ParseArrayLengths.parse(" , x = ; 1 ; 2 ; , y = ; 3 ; , ") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse(" , x = ; 1 ; 2 ; , y = ; 3 ; , ") == {
+        "x": [1, 2],
+        "y": [3],
+    }
 
 
 def test_unparse_array_lengths():
     assert ParseArrayLengths.unparse({}) == ""
     assert ParseArrayLengths.unparse({"x": [1]}) == "x=1"
-    assert ParseArrayLengths.unparse({"x": [1, 2], "y": [3]}) in {"x=1;2,y=3", "y=3,x=1;2"}
+    assert ParseArrayLengths.unparse({"x": [1, 2], "y": [3]}) in {
+        "x=1;2,y=3",
+        "y=3,x=1;2",
+    }
 
 
 def test_parse_array_lengths_roundtrip():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ from halmos.config import (
 from halmos.config import (
     toml_parser as get_toml_parser,
 )
-
+from halmos.config import ParseCSV, ParseErrorCodes, ParseArrayLengths
 
 @pytest.fixture
 def config():
@@ -185,3 +185,109 @@ def test_config_pickle(config, parser):
     # then the config object should be the same
     assert config == unpickled
     assert unpickled.value_with_source("verbose") == (3, "command-line")
+
+
+def test_parse_csv():
+    with pytest.raises(ValueError):
+        ParseCSV.parse("")
+        ParseCSV.parse(" ")
+        ParseCSV.parse(",")
+    assert ParseCSV.parse("0") == [0]
+    assert ParseCSV.parse("0,") == [0]
+    assert ParseCSV.parse("1,2,3") == [1, 2, 3]
+    assert ParseCSV.parse("1,2,3,") == [1, 2, 3]
+    assert ParseCSV.parse(" 1 , 2 , 3 ") == [1, 2, 3]
+    assert ParseCSV.parse(" , 1 , 2 , 3 , ") == [1, 2, 3]
+
+
+def test_unparse_csv():
+    assert ParseCSV.unparse([]) == ""
+    assert ParseCSV.unparse([0]) == "0"
+    assert ParseCSV.unparse([1, 2, 3]) == "1,2,3"
+
+
+def test_parse_csv_roundtrip():
+    test_cases = [
+        [0],
+        [1, 2, 3],
+    ]
+
+    for original in test_cases:
+        unparsed = ParseCSV.unparse(original)
+        parsed = ParseCSV.parse(unparsed)
+        assert parsed == original, f"Roundtrip failed for {original}"
+
+
+def test_parse_error_codes():
+    with pytest.raises(ValueError):
+        ParseErrorCodes.parse("")
+        ParseErrorCodes.parse(" ")
+        ParseErrorCodes.parse(",")
+        ParseErrorCodes.parse("1,*")
+        ParseErrorCodes.parse(",*")
+        ParseErrorCodes.parse("*,")
+    assert ParseErrorCodes.parse("*") == set()
+    assert ParseErrorCodes.parse(" * ") == set()
+    assert ParseErrorCodes.parse("0") == {0}
+    assert ParseErrorCodes.parse("0,") == {0}
+    assert ParseErrorCodes.parse("1,2,3") == {1, 2, 3}
+    assert ParseErrorCodes.parse("1,2,3,") == {1, 2, 3}
+    assert ParseErrorCodes.parse(" 1 , 2 , 3 ") == {1, 2, 3}
+    assert ParseErrorCodes.parse(" , 1 , 2 , 3 , ") == {1, 2, 3}
+    assert ParseErrorCodes.parse(" 0b10 , 0o10 , 10, 0x10 ") == {2, 8, 10, 16}
+
+
+def test_unparse_error_codes():
+    assert ParseErrorCodes.unparse(set()) == "*"
+    assert ParseErrorCodes.unparse({0}) == "0x00"
+    assert ParseErrorCodes.unparse({1, 2}) in {"0x01,0x02", "0x02,0x01"}
+
+
+def test_parse_error_codes_roundtrip():
+    test_cases = [
+        set(),
+        {0},
+        {1, 2},
+        {1, 2, 3},
+    ]
+
+    for original in test_cases:
+        unparsed = ParseErrorCodes.unparse(original)
+        parsed = ParseErrorCodes.parse(unparsed)
+        assert parsed == original, f"Roundtrip failed for {original}"
+
+
+def test_parse_array_lengths():
+    assert ParseArrayLengths.parse("") == {}
+    assert ParseArrayLengths.parse(" ") == {}
+    assert ParseArrayLengths.parse(",") == {}
+    assert ParseArrayLengths.parse("x=1") == {"x": [1]}
+    assert ParseArrayLengths.parse("x=1,") == {"x": [1]}
+    assert ParseArrayLengths.parse("x=1;2,y=3") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse("x=1;2;,y=3") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse("x=1;2,y=3;") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse("x=1;2,y=3,") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse("x=1;2;,y=3;,") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse(" x = 1 ; 2 , y = 3 ") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse(" , x = 1 ; 2 , y = 3 , ") == {"x": [1, 2], "y": [3]}
+    assert ParseArrayLengths.parse(" , x = ; 1 ; 2 ; , y = ; 3 ; , ") == {"x": [1, 2], "y": [3]}
+
+
+def test_unparse_array_lengths():
+    assert ParseArrayLengths.unparse({}) == ""
+    assert ParseArrayLengths.unparse({"x": [1]}) == "x=1"
+    assert ParseArrayLengths.unparse({"x": [1, 2], "y": [3]}) in {"x=1;2,y=3", "y=3,x=1;2"}
+
+
+def test_parse_array_lengths_roundtrip():
+    test_cases = [
+        {},
+        {"x": [1]},
+        {"x": [1, 2], "y": [3]},
+        {"x": [1, 2, 3], "y": [4, 5], "z": [6]},
+    ]
+
+    for original in test_cases:
+        unparsed = ParseArrayLengths.unparse(original)
+        parsed = ParseArrayLengths.parse(unparsed)
+        assert parsed == original, f"Roundtrip failed for {original}"


### PR DESCRIPTION
Certain option values (e.g., `--panic-error-codes`) are of non-primitive types, and not all of these types can be represented in TOML syntax, e.g., sets.

This PR ensures that these non-primitive type values are unparsed to their string representation when generating a TOML config file, so that they can be parsed back later when processing the config file.