### PR TITLE
fix: exclude test contract from symbolic calls

### DIFF
--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -213,7 +213,7 @@ class Prank:
 def symbolic_storage(ex, arg, sevm, stack, step_id):
     account = uint160(arg.get_word(4))
     account_alias = sevm.resolve_address_alias(
-        ex, account, stack, step_id, branching=False
+        ex, account, stack, step_id, allow_branching=False
     )
 
     if account_alias is None:
@@ -649,7 +649,7 @@ class hevm_cheat_code:
             store_slot = uint256(arg.get_word(36))
             store_value = uint256(arg.get_word(68))
             store_account_alias = sevm.resolve_address_alias(
-                ex, store_account, stack, step_id, branching=False
+                ex, store_account, stack, step_id, allow_branching=False
             )
 
             if store_account_alias is None:
@@ -664,7 +664,7 @@ class hevm_cheat_code:
             load_account = uint160(arg.get_word(4))
             load_slot = uint256(arg.get_word(36))
             load_account_alias = sevm.resolve_address_alias(
-                ex, load_account, stack, step_id, branching=False
+                ex, load_account, stack, step_id, allow_branching=False
             )
 
             if load_account_alias is None:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1858,6 +1858,9 @@ class SEVM:
 
         potential_aliases = []
         for addr in ex.code:
+            # exclude the test contract from alias candidates
+            if addr == FOUNDRY_TEST:
+                continue
             alias_cond = target == addr
             if ex.check(alias_cond) != unsat:
                 if self.options.debug:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1889,7 +1889,7 @@ class SEVM:
             stack.push(new_ex, step_id)
 
         addr, cond = head
-        ex.path.append(cond)
+        ex.path.append(cond, branching=True)
         ex.alias[target] = addr
         return addr
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1835,7 +1835,7 @@ class SEVM:
         self.storage_model.store(ex, addr, loc, val)
 
     def resolve_address_alias(
-        self, ex: Exec, target: Address, stack, step_id, branching=True
+        self, ex: Exec, target: Address, stack, step_id, allow_branching=True
     ) -> Address:
         assert_bv(target)
         assert_address(target)
@@ -1880,7 +1880,7 @@ class SEVM:
 
         head, *tail = potential_aliases
 
-        if not branching and tail:
+        if not allow_branching and tail:
             raise HalmosException(f"multiple aliases exist: {hexify(target)}")
 
         for addr, cond in tail:

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -3723,6 +3723,17 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/SymbolicCall.t.sol:SymbolicCallTest": [
+            {
+                "name": "check_foo(address)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/TestConstructor.t.sol:TestConstructorTest": [
             {
                 "name": "check_value()",

--- a/tests/regression/test/SymbolicCall.t.sol
+++ b/tests/regression/test/SymbolicCall.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+import {IERC721TokenReceiver} from "forge-std/interfaces/IERC721.sol";
+
+contract C {
+    function foo() public pure returns (bool) {
+        return true;
+    }
+}
+
+contract SymbolicCallTest is Test {
+    C c1;
+    C c2;
+
+    function setUp() public {
+        c1 = new C();
+        c2 = new C();
+    }
+
+    function check_foo(address addr) public {
+        (bool success,) = addr.call(abi.encodeWithSelector(C.foo.selector));
+        // this will fail if addr could be aliased to the test contract
+        assertTrue(success);
+    }
+
+    function foo() public pure returns (bool) {
+        revert();
+    }
+}

--- a/tests/regression/test/SymbolicCall.t.sol
+++ b/tests/regression/test/SymbolicCall.t.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
 
-import {IERC721TokenReceiver} from "forge-std/interfaces/IERC721.sol";
-
 contract C {
     function foo() public pure returns (bool) {
         return true;


### PR DESCRIPTION
previously, all deployed contracts, including the test contract, were considered for calls to symbolic addresses. however, the test contract is typically not expected to be involved in such symbolic calls. moreover, recursively calling back to the test contract could lead to infinite looping behavior.

now, the test contract is excluded from symbolic calls to prevent this issue.