### PR TITLE
fix: reset z3 solver objects

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Vyper
         if: ${{ matrix.project.dir == 'snekmate' }}
         run: |
-          docker run --name halmos-vyper --entrypoint uv halmos-image pip install vyper
+          docker run --name halmos-vyper --entrypoint uv halmos-image pip install git+https://github.com/vyperlang/vyper@master
           docker commit --change 'ENTRYPOINT ["halmos"]' halmos-vyper halmos-image
 
       - name: Checkout external repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.11", "3.12"]
+        storage-layout: ["solidity", "generic"]
+        cache-solver: ["", "--cache-solver"]
 
     steps:
       - name: Checkout repository
@@ -51,14 +53,5 @@ jobs:
       - name: Install halmos
         run: python -m pip install -e .
 
-      - name: Run pytest, solidity
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout solidity --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
-
-      - name: Run pytest, generic
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout generic --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
-
-      - name: Run pytest, solidity, cache solver
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout solidity --cache-solver --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
-
-      - name: Run pytest, generic, cache solver
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout generic --cache-solver --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+      - name: Run pytest
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --disable-gc --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,5 +53,11 @@ jobs:
       - name: Install halmos
         run: python -m pip install -e .
 
+      - name: Setup Z3
+        id: z3
+        uses: cda-tum/setup-z3@v1
+        with:
+          version: 4.12.6
+
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-command z3 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
         python-version: ["3.12"]
-        storage-layout: ["solidity"]
+        storage-layout: ["solidity", "generic"]
         cache-solver: [""]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.11", "3.12"]
-        storage-layout: ["solidity", "generic"]
-        cache-solver: ["", "--cache-solver"]
 
     steps:
       - name: Checkout repository
@@ -53,5 +51,14 @@ jobs:
       - name: Install halmos
         run: python -m pip install -e .
 
-      - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+      - name: Run pytest, solidity
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout solidity --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+
+      - name: Run pytest, generic
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout generic --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+
+      - name: Run pytest, solidity, cache solver
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout solidity --cache-solver --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+
+      - name: Run pytest, generic, cache solver
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout generic --cache-solver --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: false
+          submodules: recursive
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,4 +60,4 @@ jobs:
           version: 4.12.6
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-command z3 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }} -s --log-cli-level=
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-command z3 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          # note: it is faster to let foundry do a sparse checkout of the missing libraries rather than having the action do a git checkout of the submodules
+          submodules: false
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,5 @@ jobs:
       - name: Install halmos
         run: python -m pip install -e .
 
-      - name: Setup Z3
-        id: z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: 4.12.6
-
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-command z3 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        python-version: ["3.11", "3.12"]
-        storage-layout: ["solidity", "generic"]
-        cache-solver: ["", "--cache-solver"]
+        os: ["macos-latest", "ubuntu-latest"]
+        python-version: ["3.12"]
+        storage-layout: ["solidity"]
+        cache-solver: [""]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,4 +60,4 @@ jobs:
           version: 4.12.6
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-command z3 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-max-memory 2048 --solver-command z3 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }} -s --log-cli-level=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
-        python-version: ["3.12"]
-        storage-layout: ["solidity"]
-        cache-solver: [""]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        python-version: ["3.11", "3.12"]
+        storage-layout: ["solidity", "generic"]
+        cache-solver: ["", "--cache-solver"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --disable-gc --solver-max-memory 2048 --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --disable-gc --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
         python-version: ["3.12"]
-        storage-layout: ["solidity", "generic"]
+        storage-layout: ["solidity"]
         cache-solver: [""]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.11", "3.12"]
-        parallel: ["", "--test-parallel"]
         storage-layout: ["solidity", "generic"]
         cache-solver: ["", "--cache-solver"]
 
@@ -54,4 +53,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st ${{ matrix.parallel }} --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 black
 pre-commit
 pytest
-psutil

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black
 pre-commit
 pytest
+psutil

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 black
 pre-commit
 pytest
-pytest-xdist

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -18,7 +18,6 @@ from enum import Enum
 from importlib import metadata
 
 from z3 import (
-    Solver,
     Z3_OP_CONCAT,
     BitVec,
     BitVecNumRef,
@@ -27,6 +26,7 @@ from z3 import (
     CheckSatResult,
     Context,
     ModelRef,
+    Solver,
     is_app,
     is_bv,
     sat,

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1078,6 +1078,7 @@ def solve(
             if args.cache_solver and result == unsat
             else None
         )
+        solver.reset()
         return result, model, unsat_core
 
 

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -11,7 +11,7 @@ import time
 import traceback
 import uuid
 from collections import Counter
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -637,7 +637,7 @@ def run(
     models: list[ModelWithContext] = []
     stuck = []
 
-    process_pool = ProcessPoolExecutor(max_workers=args.solver_threads)
+    thread_pool = ThreadPoolExecutor(max_workers=args.solver_threads)
     result_exs = []
     future_models = []
     counterexamples = []
@@ -703,7 +703,7 @@ def run(
 
             query = ex.path.to_smt2(args)
 
-            future_model = process_pool.submit(
+            future_model = thread_pool.submit(
                 gen_model_from_sexpr,
                 GenModelArgs(args, idx, query, unsat_cores, dump_dirname),
             )
@@ -738,10 +738,10 @@ def run(
         ):
             time.sleep(1)
 
-        process_pool.shutdown(wait=False, cancel_futures=True)
+        thread_pool.shutdown(wait=False, cancel_futures=True)
 
     else:
-        process_pool.shutdown(wait=True)
+        thread_pool.shutdown(wait=True)
 
     counter = Counter(str(m.result) for m in models)
     if counter["sat"] > 0:

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -507,6 +507,7 @@ def setup(
     return setup_ex
 
 
+@dataclass
 class PotentialModel:
     model: AnyModel
     is_valid: bool

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0
 
+import gc
 import io
 import json
 import os
@@ -1336,6 +1337,9 @@ def _main(_args=None) -> MainResult:
     if args.version:
         print(f"halmos {metadata.version('halmos')}")
         return MainResult(0)
+
+    if args.disable_gc:
+        gc.disable()
 
     #
     # compile

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -774,9 +774,9 @@ def run(
 
     # return test result
     if args.minimal_json_output:
-        return TestResult(funsig, exitcode, len(counterexamples))
+        test_result = TestResult(funsig, exitcode, len(counterexamples))
     else:
-        return TestResult(
+        test_result = TestResult(
             funsig,
             exitcode,
             len(counterexamples),
@@ -785,6 +785,11 @@ def run(
             (timer.elapsed(), timer["paths"].elapsed(), timer["models"].elapsed()),
             len(logs.bounded_loops),
         )
+
+    # reset any remaining solver states from the default context
+    solver.reset()
+
+    return test_result
 
 
 @dataclass(frozen=True)
@@ -954,6 +959,9 @@ def run_sequential(run_args: RunArgs) -> list[TestResult]:
             continue
 
         test_results.append(test_result)
+
+    # reset any remaining solver states from the default context
+    setup_ex.path.solver.reset()
 
     return test_results
 

--- a/src/halmos/calldata.py
+++ b/src/halmos/calldata.py
@@ -12,7 +12,7 @@ from z3 import (
 
 from .bytevec import ByteVec
 from .config import Config as HalmosConfig
-from .utils import con
+from .utils import con, uid
 
 
 @dataclass(frozen=True)
@@ -144,7 +144,7 @@ class Calldata:
                     f"Warning: no size provided for {name}; default value {sizes} will be used."
                 )
 
-        size_var = BitVec(f"p_{name}_length_{self.new_symbol_id():>02}", 256)
+        size_var = BitVec(f"p_{name}_length_{uid()}_{self.new_symbol_id():>02}", 256)
 
         self.dyn_params.append(DynamicParam(name, sizes, size_var, typ))
 
@@ -222,7 +222,7 @@ class Calldata:
             return EncodingResult([size_var] + encoded.data, 32 + encoded.size, False)
 
         if isinstance(typ, BaseType):
-            new_symbol = f"p_{name}_{typ.typ}_{self.new_symbol_id():>02}"
+            new_symbol = f"p_{name}_{typ.typ}_{uid()}_{self.new_symbol_id():>02}"
 
             # bytes, string
             if typ.typ in ["bytes", "string"]:

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -55,6 +55,7 @@ from .utils import (
     red,
     secp256k1n,
     stripped,
+    uid,
     uint160,
     uint256,
 )
@@ -292,10 +293,12 @@ def create_calldata_generic(ex, sevm, contract_name, filename=None, include_view
     results.append(encode_tuple_bytes(b""))
 
     # nonempty calldata for fallback()
-    fallback_selector = BitVec(f"fallback_selector_{ex.new_symbol_id():>02}", 4 * 8)
+    fallback_selector = BitVec(
+        f"fallback_selector_{uid()}_{ex.new_symbol_id():>02}", 4 * 8
+    )
     fallback_input_length = 1024  # TODO: configurable
     fallback_input = BitVec(
-        f"fallback_input_{ex.new_symbol_id():>02}", fallback_input_length * 8
+        f"fallback_input_{uid()}_{ex.new_symbol_id():>02}", fallback_input_length * 8
     )
     results.append(encode_tuple_bytes(Concat(fallback_selector, fallback_input)))
 
@@ -328,7 +331,7 @@ def create_calldata_generic(ex, sevm, contract_name, filename=None, include_view
 
 
 def create_generic(ex, bits: int, var_name: str, type_name: str) -> BitVecRef:
-    label = f"halmos_{var_name}_{type_name}_{ex.new_symbol_id():>02}"
+    label = f"halmos_{var_name}_{type_name}_{uid()}_{ex.new_symbol_id():>02}"
     return BitVec(label, BitVecSorts[bits])
 
 

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -382,6 +382,12 @@ class Config:
         group=debugging,
     )
 
+    disable_gc: bool = arg(
+        help="disable Python's automatic garbage collection for cyclic objects. This does not affect reference counting based garbage collection.",
+        global_default=False,
+        group=debugging,
+    )
+
     ### Build options
 
     forge_build_out: str = arg(

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1237,6 +1237,7 @@ class SolidityStorage(Storage):
         num_keys = len(keys)
         size_keys = cls.bitsize(keys)
         return Array(
+            # note: uuid is excluded to be deterministic
             f"storage_{id_str(addr)}_{slot}_{num_keys}_{size_keys}_00",
             BitVecSorts[size_keys],
             BitVecSort256,
@@ -1268,6 +1269,7 @@ class SolidityStorage(Storage):
         # size_keys == 0
         mapping[size_keys] = (
             BitVec(
+                # note: uuid is excluded to be deterministic
                 f"storage_{id_str(addr)}_{slot}_{num_keys}_{size_keys}_00",
                 BitVecSort256,
             )
@@ -1406,6 +1408,7 @@ class GenericStorage(Storage):
     @classmethod
     def empty(cls, addr: BitVecRef, loc: BitVecRef) -> ArrayRef:
         return Array(
+            # note: uuid is excluded to be deterministic
             f"storage_{id_str(addr)}_{loc.size()}_00",
             BitVecSorts[loc.size()],
             BitVecSort256,

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -735,6 +735,7 @@ class Path:
         ids = [str(cond.get_id()) for cond in self.conditions]
 
         if args.cache_solver:
+            # TODO: investigate whether a separate context is necessary here
             tmp_solver = create_solver(ctx=Context())
             for cond in self.conditions:
                 tmp_solver.assert_and_track(

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -112,6 +112,7 @@ from .utils import (
     sha3_inv,
     str_opcode,
     stripped,
+    uid,
     uint8,
     uint160,
     uint256,
@@ -1090,7 +1091,7 @@ class Exec:  # an execution path
         assert_uint256(value)
         addr = uint160(addr)
         new_balance_var = Array(
-            f"balance_{1+len(self.balances):>02}", BitVecSort160, BitVecSort256
+            f"balance_{uid()}_{1+len(self.balances):>02}", BitVecSort160, BitVecSort256
         )
         new_balance = Store(self.balance, addr, value)
         self.path.append(new_balance_var == new_balance)
@@ -1310,7 +1311,7 @@ class SolidityStorage(Storage):
             return
 
         new_storage_var = Array(
-            f"storage_{id_str(addr)}_{slot}_{num_keys}_{size_keys}_{1+len(ex.storages):>02}",
+            f"storage_{id_str(addr)}_{slot}_{num_keys}_{size_keys}_{uid()}_{1+len(ex.storages):>02}",
             BitVecSorts[size_keys],
             BitVecSort256,
         )
@@ -1453,7 +1454,7 @@ class GenericStorage(Storage):
         mapping = ex.storage[addr].mapping
 
         new_storage_var = Array(
-            f"storage_{id_str(addr)}_{size_keys}_{1+len(ex.storages):>02}",
+            f"storage_{id_str(addr)}_{size_keys}_{uid()}_{1+len(ex.storages):>02}",
             BitVecSorts[size_keys],
             BitVecSort256,
         )
@@ -2156,7 +2157,7 @@ class SEVM:
 
             # push exit code
             exit_code_var = BitVec(
-                f"call_exit_code_{ex.new_call_id():>02}", BitVecSort256
+                f"call_exit_code_{uid()}_{ex.new_call_id():>02}", BitVecSort256
             )
             ex.path.append(exit_code_var == exit_code)
             ex.st.push(exit_code if is_bv_value(exit_code) else exit_code_var)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -26,6 +26,7 @@ from z3 import (
     BoolVal,
     CheckSatResult,
     Concat,
+    Context,
     Extract,
     Function,
     If,
@@ -35,7 +36,6 @@ from z3 import (
     Select,
     SignExt,
     Solver,
-    SolverFor,
     SRem,
     Store,
     UDiv,
@@ -92,6 +92,7 @@ from .utils import (
     con,
     con_addr,
     concat,
+    create_solver,
     debug,
     extract_bytes,
     f_ecrecover,
@@ -734,10 +735,13 @@ class Path:
         ids = [str(cond.get_id()) for cond in self.conditions]
 
         if args.cache_solver:
-            tmp_solver = SolverFor("QF_AUFBV")
+            tmp_solver = create_solver(ctx=Context())
             for cond in self.conditions:
-                tmp_solver.assert_and_track(cond, str(cond.get_id()))
+                tmp_solver.assert_and_track(
+                    cond.translate(tmp_solver.ctx), str(cond.get_id())
+                )
             query = tmp_solver.to_smt2()
+            tmp_solver.reset()
         else:
             query = self.solver.to_smt2()
         query = query.replace("(check-sat)", "")  # see __main__.solve()

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -221,9 +221,6 @@ def create_solver(logic="QF_AUFBV", ctx=None, timeout=0, max_memory=0):
     # QF_AUFBV: quantifier-free bitvector + array theory: https://smtlib.cs.uiowa.edu/logics.shtml
     solver = SolverFor(logic, ctx=ctx)
 
-    # reset any remaining solver states from the default context
-    solver.reset()
-
     # set timeout
     solver.set(timeout=timeout)
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -2,6 +2,7 @@
 
 import math
 import re
+import uuid
 from functools import partial
 from timeit import default_timer as timer
 from typing import Any
@@ -108,6 +109,10 @@ def f_sha3_name(bitsize: int) -> str:
 
 f_sha3_256_name = f_sha3_name(256)
 f_sha3_512_name = f_sha3_name(512)
+
+
+def uid() -> str:
+    return uuid.uuid4().hex[:7]
 
 
 def wrap(x: Any) -> Word:

--- a/tests/test_halmos.py
+++ b/tests/test_halmos.py
@@ -2,7 +2,6 @@ import dataclasses
 import json
 
 import pytest
-import gc
 
 from halmos.__main__ import _main, rendered_calldata
 from halmos.bytevec import ByteVec
@@ -47,7 +46,6 @@ from halmos.sevm import con
     ),
 )
 def test_main(cmd, expected_path, halmos_options):
-    gc.disable()
     actual = dataclasses.asdict(_main(cmd + halmos_options.split()))
     with open(expected_path, encoding="utf8") as f:
         expected = json.load(f)

--- a/tests/test_halmos.py
+++ b/tests/test_halmos.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 
 import pytest
+import psutil
 
 from halmos.__main__ import _main, rendered_calldata
 from halmos.bytevec import ByteVec
@@ -46,7 +47,11 @@ from halmos.sevm import con
     ),
 )
 def test_main(cmd, expected_path, halmos_options):
+    print(psutil.virtual_memory())
+    print(psutil.Process().memory_info())
     actual = dataclasses.asdict(_main(cmd + halmos_options.split()))
+    print(psutil.virtual_memory())
+    print(psutil.Process().memory_info())
     with open(expected_path, encoding="utf8") as f:
         expected = json.load(f)
     assert expected["exitcode"] == actual["exitcode"]

--- a/tests/test_halmos.py
+++ b/tests/test_halmos.py
@@ -2,7 +2,6 @@ import dataclasses
 import json
 
 import pytest
-import psutil
 
 from halmos.__main__ import _main, rendered_calldata
 from halmos.bytevec import ByteVec
@@ -47,11 +46,7 @@ from halmos.sevm import con
     ),
 )
 def test_main(cmd, expected_path, halmos_options):
-    print(psutil.virtual_memory())
-    print(psutil.Process().memory_info())
     actual = dataclasses.asdict(_main(cmd + halmos_options.split()))
-    print(psutil.virtual_memory())
-    print(psutil.Process().memory_info())
     with open(expected_path, encoding="utf8") as f:
         expected = json.load(f)
     assert expected["exitcode"] == actual["exitcode"]

--- a/tests/test_halmos.py
+++ b/tests/test_halmos.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 
 import pytest
+import gc
 
 from halmos.__main__ import _main, rendered_calldata
 from halmos.bytevec import ByteVec
@@ -46,6 +47,7 @@ from halmos.sevm import con
     ),
 )
 def test_main(cmd, expected_path, halmos_options):
+    gc.disable()
     actual = dataclasses.asdict(_main(cmd + halmos_options.split()))
     with open(expected_path, encoding="utf8") as f:
         expected = json.load(f)


### PR DESCRIPTION
this pr addresses several issues related to flakiness in ci runs, including:

- **solver resets**: using multiple z3 solver objects, especially with the global context, may cause segfault after garbage collection of those z3 objects. this has led to flakiness in ci runs. this pr ensures that solver objects are properly reset at the end of their use.
  - this pr subsumes #390, which simplifies the implementation of proper solver resets.

- **solver contexts**: where possible, certain independent solvers are now created with their own context (separate from the global context) to further reduce the risk of conflicts.

- **symbol names**: moreover, to avoid name clashes, z3 symbol names now include a uuid to ensure uniqueness.

- **python garbage collection**: there was an issue at the python level with automatic garbage collection for cyclic objects, which sometimes incorrectly collected z3 objects that were still in use. to address this, a new `--disable-gc` flag has been added and is used in ci tests.

