### PR TITLE
feat: remove test parallel mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python-version: ["3.11", "3.12"]
-        parallel: ["", "--test-parallel"]
         storage-layout: ["solidity", "generic"]
         cache-solver: ["", "--cache-solver"]
 
@@ -54,4 +53,4 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run pytest
-        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st ${{ matrix.parallel }} --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}
+        run: pytest -v -k "not long and not ffi" --ignore=tests/lib --halmos-options="-st --solver-threads 1 --storage-layout ${{ matrix.storage-layout }} ${{ matrix.cache-solver }} --solver-timeout-assertion 0 ${{ inputs.halmos-options }}" ${{ inputs.pytest-options }}

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -11,7 +11,7 @@ import time
 import traceback
 import uuid
 from collections import Counter
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -612,7 +612,7 @@ def run(
     models: list[ModelWithContext] = []
     stuck = []
 
-    thread_pool = ThreadPoolExecutor(max_workers=args.solver_threads)
+    process_pool = ProcessPoolExecutor(max_workers=args.solver_threads)
     result_exs = []
     future_models = []
     counterexamples = []
@@ -678,7 +678,7 @@ def run(
 
             query = ex.path.to_smt2(args)
 
-            future_model = thread_pool.submit(
+            future_model = process_pool.submit(
                 gen_model_from_sexpr,
                 GenModelArgs(args, idx, query, unsat_cores, dump_dirname),
             )
@@ -713,10 +713,10 @@ def run(
         ):
             time.sleep(1)
 
-        thread_pool.shutdown(wait=False, cancel_futures=True)
+        process_pool.shutdown(wait=False, cancel_futures=True)
 
     else:
-        thread_pool.shutdown(wait=True)
+        process_pool.shutdown(wait=True)
 
     counter = Counter(str(m.result) for m in models)
     if counter["sat"] > 0:
@@ -787,56 +787,6 @@ def run(
         )
 
 
-@dataclass(frozen=True)
-class SetupAndRunSingleArgs:
-    creation_hexcode: str
-    deployed_hexcode: str
-    abi: dict
-    setup_info: FunctionInfo
-    fun_info: FunctionInfo
-    setup_args: HalmosConfig
-    args: HalmosConfig
-    libs: dict
-    build_out_map: dict
-
-
-def setup_and_run_single(fn_args: SetupAndRunSingleArgs) -> list[TestResult]:
-    BuildOut().set_build_out(fn_args.build_out_map)
-
-    args = fn_args.args
-    try:
-        setup_ex = setup(
-            fn_args.creation_hexcode,
-            fn_args.deployed_hexcode,
-            fn_args.abi,
-            fn_args.setup_info,
-            fn_args.setup_args,
-            fn_args.libs,
-        )
-    except Exception as err:
-        error(f"Error: {fn_args.setup_info.sig} failed: {type(err).__name__}: {err}")
-
-        if args.debug:
-            traceback.print_exc()
-        return []
-
-    try:
-        test_result = run(
-            setup_ex,
-            fn_args.abi,
-            fn_args.fun_info,
-            fn_args.args,
-        )
-    except Exception as err:
-        print(f"{color_error('[ERROR]')} {fn_args.fun_info.sig}")
-        error(f"{type(err).__name__}: {err}")
-        if args.debug:
-            traceback.print_exc()
-        return [TestResult(fn_args.fun_info.sig, Exitcode.EXCEPTION.value)]
-
-    return [test_result]
-
-
 def extract_setup(methodIdentifiers: dict[str, str]) -> FunctionInfo:
     setup_sigs = sorted(
         [
@@ -871,46 +821,6 @@ class RunArgs:
     libs: dict
 
     build_out_map: dict
-
-
-def run_parallel(run_args: RunArgs) -> list[TestResult]:
-    args = run_args.args
-    creation_hexcode, deployed_hexcode, abi, methodIdentifiers, libs = (
-        run_args.creation_hexcode,
-        run_args.deployed_hexcode,
-        run_args.abi,
-        run_args.methodIdentifiers,
-        run_args.libs,
-    )
-
-    setup_info = extract_setup(methodIdentifiers)
-    setup_config = with_devdoc(args, setup_info.sig, run_args.contract_json)
-    fun_infos = [
-        FunctionInfo(funsig.split("(")[0], funsig, methodIdentifiers[funsig])
-        for funsig in run_args.funsigs
-    ]
-
-    single_run_args = [
-        SetupAndRunSingleArgs(
-            creation_hexcode,
-            deployed_hexcode,
-            abi,
-            setup_info,
-            fun_info,
-            setup_config,
-            with_devdoc(args, fun_info.sig, run_args.contract_json),
-            libs,
-            run_args.build_out_map,
-        )
-        for fun_info in fun_infos
-    ]
-
-    # dispatch to the shared process pool
-    with ProcessPoolExecutor() as process_pool:
-        test_results = list(process_pool.map(setup_and_run_single, single_run_args))
-    test_results = sum(test_results, [])  # flatten lists
-
-    return test_results
 
 
 def run_sequential(run_args: RunArgs) -> list[TestResult]:
@@ -1530,9 +1440,7 @@ def _main(_args=None) -> MainResult:
             build_out_map,
         )
 
-        enable_parallel = args.test_parallel and num_found > 1
-        run_method = run_parallel if enable_parallel else run_sequential
-        test_results = run_method(run_args)
+        test_results = run_sequential(run_args)
 
         num_passed = sum(r.exitcode == 0 for r in test_results)
         num_failed = num_found - num_passed

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -11,7 +11,7 @@ import time
 import traceback
 import uuid
 from collections import Counter
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -612,7 +612,7 @@ def run(
     models: list[ModelWithContext] = []
     stuck = []
 
-    process_pool = ProcessPoolExecutor(max_workers=args.solver_threads)
+    thread_pool = ThreadPoolExecutor(max_workers=args.solver_threads)
     result_exs = []
     future_models = []
     counterexamples = []
@@ -678,7 +678,7 @@ def run(
 
             query = ex.path.to_smt2(args)
 
-            future_model = process_pool.submit(
+            future_model = thread_pool.submit(
                 gen_model_from_sexpr,
                 GenModelArgs(args, idx, query, unsat_cores, dump_dirname),
             )
@@ -713,10 +713,10 @@ def run(
         ):
             time.sleep(1)
 
-        process_pool.shutdown(wait=False, cancel_futures=True)
+        thread_pool.shutdown(wait=False, cancel_futures=True)
 
     else:
-        process_pool.shutdown(wait=True)
+        thread_pool.shutdown(wait=True)
 
     counter = Counter(str(m.result) for m in models)
     if counter["sat"] > 0:

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -423,10 +423,6 @@ class Config:
 
     ### Experimental options
 
-    test_parallel: bool = arg(
-        help="run tests in parallel", global_default=False, group=experimental
-    )
-
     symbolic_jump: bool = arg(
         help="support symbolic jump destination",
         global_default=False,
@@ -434,6 +430,10 @@ class Config:
     )
 
     ### Deprecated
+
+    test_parallel: bool = arg(
+        help="(Deprecated; no-op) run tests in parallel", global_default=False, group=deprecated
+    )
 
     solver_parallel: bool = arg(
         help="(Deprecated; no-op; use --solver-threads instead) run assertion solvers in parallel",

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -432,7 +432,9 @@ class Config:
     ### Deprecated
 
     test_parallel: bool = arg(
-        help="(Deprecated; no-op) run tests in parallel", global_default=False, group=deprecated
+        help="(Deprecated; no-op) run tests in parallel",
+        global_default=False,
+        group=deprecated,
     )
 
     solver_parallel: bool = arg(

--- a/tests/regression/halmos.toml
+++ b/tests/regression/halmos.toml
@@ -80,6 +80,9 @@ print-mem = false
 # print all final execution states
 print-states = false
 
+# print successful execution states
+print-success-states = false
+
 # print failed execution states
 print-failed-states = false
 
@@ -133,9 +136,6 @@ cache-solver = false
 ################################################################################
 #                             Experimental options                             #
 ################################################################################
-
-# run tests in parallel
-test-parallel = false
 
 # support symbolic jump destination
 symbolic-jump = false


### PR DESCRIPTION
the test parallel mode is not much used and may lead to performance degradation when used together parallel solving (which is now always enabled). this is due to too many parallel cores running (# of parallel tests * # of parallel solvers). this issue is expected to worsen with the introduction of portfolio solving later.

this pr removes the test parallel feature.