### PR TITLE
update actions/setup-python to v5

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,5 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
v3 uses a deprecated node version