### PR TITLE
👷 Pin Vyper Temporarily to Specific Commit

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Vyper
         if: ${{ matrix.project.dir == 'snekmate' }}
         run: |
-          docker run --name halmos-vyper --entrypoint uv halmos-image pip install pip install git+https://github.com/vyperlang/vyper@6606ded787184be82de9ea05aeb1b61bcd219d6a
+          docker run --name halmos-vyper --entrypoint uv halmos-image pip install git+https://github.com/vyperlang/vyper@6606ded787184be82de9ea05aeb1b61bcd219d6a
           docker commit --change 'ENTRYPOINT ["halmos"]' halmos-vyper halmos-image
 
       - name: Checkout external repo

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Vyper
         if: ${{ matrix.project.dir == 'snekmate' }}
         run: |
-          docker run --name halmos-vyper --entrypoint uv halmos-image pip install git+https://github.com/vyperlang/vyper@master
+          docker run --name halmos-vyper --entrypoint uv halmos-image pip install pip install git+https://github.com/vyperlang/vyper@6606ded787184be82de9ea05aeb1b61bcd219d6a
           docker commit --change 'ENTRYPOINT ["halmos"]' halmos-vyper halmos-image
 
       - name: Checkout external repo


### PR DESCRIPTION
The Vyper commit https://github.com/vyperlang/vyper/commit/6843e7915729f3a3ea0d8c765dffa52033f5818e introduced an unexpected compilation regression. Until it's fixed, we pin the Vyper version used in CI for the snekmate tests to commit: https://github.com/vyperlang/vyper/commit/6606ded787184be82de9ea05aeb1b61bcd219d6a.