### PR TITLE
fix: improve error-handling for unsupported symbolic names in cheatcodes

### DIFF
--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -30,7 +30,7 @@ from .calldata import (
     get_abi,
     mk_calldata,
 )
-from .exceptions import FailCheatcode, HalmosException, InfeasiblePath
+from .exceptions import FailCheatcode, HalmosException, InfeasiblePath, NotConcreteError
 from .mapper import BuildOut
 from .utils import (
     Address,
@@ -74,6 +74,9 @@ f_sign_s = Function("f_sign_s", BitVecSort256, BitVecSort256, BitVecSort256)
 
 
 def name_of(x: str) -> str:
+    if not isinstance(x, str):
+        raise NotConcreteError(f"expected concrete string but got: {x}")
+
     return re.sub(r"\s+", "_", x)
 
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -448,14 +448,14 @@ class State:
         self.stack[-(n + 1)], self.stack[-1] = self.stack[-1], self.stack[-(n + 1)]
 
     def mloc(self, subst: dict = None) -> int:
-        loc: int = int_of(self.pop(), subst, "symbolic memory offset")
+        loc: int = int_of(self.pop(), "symbolic memory offset", subst)
         if loc > MAX_MEMORY_SIZE:
             raise OutOfGasError(f"MLOAD {loc} > MAX_MEMORY_SIZE")
         return loc
 
     def ret(self, subst: dict = None) -> ByteVec:
         loc: int = self.mloc(subst)
-        size: int = int_of(self.pop(), subst, "symbolic return data size")
+        size: int = int_of(self.pop(), "symbolic return data size", subst)
 
         returndata_slice = self.memory.slice(loc, loc + size)
         return returndata_slice
@@ -1276,7 +1276,7 @@ class Exec:  # an execution path
         return self.st.ret(self.path.concretization.substitution)
 
     def int_of(self, x: Any, err: str = None) -> int:
-        return int_of(x, self.path.concretization.substitution, err)
+        return int_of(x, err, self.path.concretization.substitution)
 
 
 class Storage:

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -351,7 +351,7 @@ def unbox_int(x: Any) -> Any:
     return x
 
 
-def int_of(x: Any, subst: dict = None, err: str = None) -> int:
+def int_of(x: Any, err: str = None, subst: dict = None) -> int:
     """
     Converts int-like objects to int or raises NotConcreteError
     """

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1340,6 +1340,15 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_extract_string_argument_fail(string)",
+                "exitcode": 3,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/HalmosCheatCode.t.sol:HalmosCreateCalldataTest": [

--- a/tests/regression/test/HalmosCheatCode.t.sol
+++ b/tests/regression/test/HalmosCheatCode.t.sol
@@ -138,6 +138,13 @@ contract HalmosCheatCodeTest is SymTest, Test {
         // symbolic storage is not allowed for a nonexistent account
         svm.enableSymbolicStorage(address(0xdeadbeef)); // HalmosException
     }
+
+    /// @custom:halmos --array-lengths name=1
+    function check_extract_string_argument_fail(string memory name) public {
+        uint x = svm.createUint256(name);
+        console.log(x);
+        assert(true);
+    }
 }
 
 /// @custom:halmos --default-bytes-lengths 0,65


### PR DESCRIPTION
provide a better error message when symbolic string terms are passed to cheatcodes that require concrete string values.