### PR TITLE
perf: improve hash injectivity constraints

### DIFF
--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -109,6 +109,14 @@ def f_sha3_name(bitsize: int) -> str:
     return f"f_sha3_{bitsize}"
 
 
+def f_inv_sha3_name(bitsize: int) -> str:
+    return f"f_inv_sha3_{bitsize}"
+
+
+# TODO: explore the impact of using a smaller bitsize for the range sort
+f_inv_sha3_size = Function("f_inv_sha3_size", BitVecSort256, BitVecSort256)
+
+
 f_sha3_0_name = f_sha3_name(0)
 f_sha3_256_name = f_sha3_name(256)
 f_sha3_512_name = f_sha3_name(512)


### PR DESCRIPTION
Previously, we formulated the hash injectivity axiom as `hash(x) == hash(y) ==> x == y`, which required generating local constraints for all combinations of hash inputs, resulting in O(n^2).

Now, we reformulate the injectivity axiom as "there exists f, such that `f(hash(x)) == x`," which requires only O(n) constraints, each of which is independent from other constraints.