### PR TITLE
docs: Fix grammatical error getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # How to write symbolic tests with Halmos
 
-Symbolic tests looks similar to fuzz tests, but there are certain differences that need to be understood. This guide will walk you through the process of writing symbolic tests, highlighting the differences compared to fuzz tests. It is intended for those who are already familiar with [Dapptools]-/[Foundry]-style fuzz tests. If you haven't experienced fuzz tests before, please refer to the [Foundry document][Foundry Fuzz Testing] to grasp the basic concepts.
+Symbolic tests look similar to fuzz tests, but there are certain differences that need to be understood. This guide will walk you through the process of writing symbolic tests, highlighting the differences compared to fuzz tests. It is intended for those who are already familiar with [Dapptools]-/[Foundry]-style fuzz tests. If you haven't experienced fuzz tests before, please refer to the [Foundry document][Foundry Fuzz Testing] to grasp the basic concepts.
 
 [Dapptools]: <https://dapp.tools/>
 [Foundry]: <https://book.getfoundry.sh/>


### PR DESCRIPTION
<img width="860" alt="Снимок экрана 2024-12-06 в 13 27 05" src="https://github.com/user-attachments/assets/22c8eef8-2336-415e-990b-7aeaf135fa19">

The phrase "Symbolic tests looks similar to fuzz tests" was using an incorrect form of the verb "look." Since "tests" is plural, the verb should be "look" instead of "looks."

The corrected sentence now reads:
"Symbolic tests look similar to fuzz tests."