### PR TITLE
Fix nested prank error message

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -453,7 +453,7 @@ def setup(
                 print(f"{setup_sig} trace #{idx+1}:")
                 render_trace(setup_ex.context)
 
-            if not setup_ex.context.output.error:
+            if not (err := setup_ex.context.output.error):
                 setup_exs_no_error.append((setup_ex, setup_ex.path.to_smt2(args)))
 
             else:
@@ -461,7 +461,7 @@ def setup(
                 if opcode not in [EVM.REVERT, EVM.INVALID]:
                     warn_code(
                         INTERNAL_ERROR,
-                        f"Warning: {setup_sig} execution encountered an issue at {mnemonic(opcode)}: {error}",
+                        f"in {setup_sig}, executing {mnemonic(opcode)} failed with: {err}",
                     )
 
                 # only render the trace if we didn't already do it
@@ -887,7 +887,7 @@ def run_sequential(run_args: RunArgs) -> list[TestResult]:
             setup_solver,
         )
     except Exception as err:
-        error(f"Error: {setup_info.sig} failed: {type(err).__name__}: {err}")
+        error(f"{setup_info.sig} failed: {type(err).__name__}: {err}")
         if args.debug:
             traceback.print_exc()
         # reset any remaining solver states from the default context
@@ -1500,7 +1500,7 @@ def _main(_args=None) -> MainResult:
 
     if total_found == 0:
         error(
-            "Error: No tests with"
+            "No tests with"
             + f" --match-contract '{contract_regex(args)}'"
             + f" --match-test '{test_regex(args)}'"
         )

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -602,7 +602,9 @@ class hevm_cheat_code:
             sender = uint160(arg.get_word(4))
             result = ex.context.prank.prank(sender)
             if not result:
-                raise HalmosException("You have an active prank already.")
+                raise HalmosException(
+                    "can not call vm.prank(address) with an active prank"
+                )
             return ret
 
         # vm.prank(address sender, address origin)
@@ -611,7 +613,9 @@ class hevm_cheat_code:
             origin = uint160(arg.get_word(36))
             result = ex.context.prank.prank(sender, origin)
             if not result:
-                raise HalmosException("You have an active prank already.")
+                raise HalmosException(
+                    "can not call vm.prank(address, address) with an active prank"
+                )
             return ret
 
         # vm.startPrank(address)
@@ -619,7 +623,9 @@ class hevm_cheat_code:
             address = uint160(arg.get_word(4))
             result = ex.context.prank.startPrank(address)
             if not result:
-                raise HalmosException("You have an active prank already.")
+                raise HalmosException(
+                    "can not call vm.startPrank(address) with an active prank"
+                )
             return ret
 
         # vm.startPrank(address sender, address origin)
@@ -628,7 +634,9 @@ class hevm_cheat_code:
             origin = uint160(arg.get_word(36))
             result = ex.context.prank.startPrank(sender, origin)
             if not result:
-                raise HalmosException("You have an active prank already.")
+                raise HalmosException(
+                    "can not call vm.startPrank(address, address) with an active prank"
+                )
             return ret
 
         # vm.stopPrank()

--- a/src/halmos/logs.py
+++ b/src/halmos/logs.py
@@ -9,7 +9,7 @@ from rich.logging import RichHandler
 
 logging.basicConfig(
     format="%(message)s",
-    handlers=[RichHandler(level=logging.NOTSET, show_time=False)],
+    handlers=[RichHandler(level=logging.NOTSET, show_time=False, show_path=False)],
 )
 
 logger = logging.getLogger("halmos")


### PR DESCRIPTION
In `setUp()`:

```
WARNING  in setUp(), executing CALL failed with: can not call vm.startPrank(address) with an active prank                                                                                                                                                                                                               
         (see https://github.com/a16z/halmos/wiki/warnings#internal-error)                                                                                                                                                                                                                                              
ERROR    setUp() failed: HalmosException: No successful path found in setUp()         
```

In a test:

```
[ERROR] test_nestedPrank() (paths: 1, time: 0.01s (paths: 0.01s, models: 0.00s), bounds: [])
WARNING  Encountered can not call vm.startPrank(address) with an active prank                                                                                                                                                                                                                                           
         (see https://github.com/a16z/halmos/wiki/warnings#internal-error)                                                                                                                                                                                                                                              
```