### PR TITLE
fix: not use context manager within generator

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -20,8 +20,6 @@ from datetime import timedelta
 from enum import Enum
 from importlib import metadata
 
-import rich
-from rich.status import Status
 from z3 import (
     Z3_OP_CONCAT,
     BitVec,

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -606,7 +606,7 @@ def run(
 
     timer = NamedTimer("time")
     timer.create_subtimer("paths")
-    sevm.status.start()
+    sevm.status_start()
 
     exs = sevm.run(
         Exec(

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -15,6 +15,7 @@ from typing import (
     TypeVar,
 )
 
+import rich
 import xxhash
 from eth_hash.auto import keccak
 from rich.status import Status
@@ -1717,6 +1718,11 @@ class SEVM:
         # init storage model
         is_generic = self.options.storage_layout == "generic"
         self.storage_model = GenericStorage if is_generic else SolidityStorage
+
+    def status_start(self) -> None:
+        # clear any remaining live display before starting a new instance
+        rich.get_console().clear_live()
+        self.status.start()
 
     def div_xy_y(self, w1: Word, w2: Word) -> Word:
         # return the number of bits required to represent the given value. default = 256

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1706,11 +1706,13 @@ class SEVM:
     storage_model: type[SomeStorage]
     logs: HalmosLogs
     steps: Steps
+    status: Status
 
     def __init__(self, options: HalmosConfig) -> None:
         self.options = options
         self.logs = HalmosLogs()
         self.steps: Steps = {}
+        self.status: Status = Status("")
 
         # init storage model
         is_generic = self.options.storage_layout == "generic"
@@ -2663,10 +2665,6 @@ class SEVM:
         return ZeroExt(248, gen_nested_ite(0))
 
     def run(self, ex0: Exec) -> Iterator[Exec]:
-        with Status("") as status:
-            yield from self._run(ex0, status)
-
-    def _run(self, ex0: Exec, status: Status) -> Iterator[Exec]:
         step_id: int = 0
         stack: Worklist = Worklist()
         stack.push(ex0, 0)
@@ -2697,7 +2695,7 @@ class SEVM:
                     # hh:mm:ss
                     elapsed_fmt = timedelta(seconds=int(elapsed))
 
-                    status.update(
+                    self.status.update(
                         f"[{elapsed_fmt}] {speed:.0f} ops/s"
                         f" | completed paths: {stack.completed_paths}"
                         f" | outstanding paths: {len(stack)}"


### PR DESCRIPTION
the use of rich.status context manager within the sevm generator is not robust, as certain stop-iteration events may not be properly captured by the context manager's exit handler.

to address this, a status instance is now added as a field of the sevm class. it's explicitly started and stopped in the main.run function, controlled in the same way with the timer. also, now a single status instance is used throughout each test run, instead of two separate instances.

this is a followup to #432