### PR TITLE
fix: avoid raising internal python error on large memory access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Print foundry version
+        run: forge --version
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -476,7 +476,7 @@ class State:
                 f"memory access with {loc=} {size=} exceeds MAX_MEMORY_SIZE"
             )
 
-        return self.memory.slice(start=loc, end=loc + size)
+        return self.memory.slice(start=loc, stop=loc + size)
 
     def ret(self, subst: dict = None) -> ByteVec:
         loc: int = self.mloc(subst)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1196,7 +1196,7 @@ class Exec:  # an execution path
         self.balances[new_balance_var] = new_balance
 
     def sha3(self) -> None:
-        loc: int = self.mloc()
+        loc: int = self.int_of(self.st.pop(), "symbolic SHA3 data loc")
         size: int = self.int_of(self.st.pop(), "symbolic SHA3 data size")
         data = self.st.mslice(loc, size).unwrap() if size else b""
         sha3_image = self.sha3_data(data)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -363,9 +363,7 @@ class Message:
     def calldata_slice(self, start: int, size: int) -> ByteVec:
         """Wrapper around calldata access with a size check."""
         if size > MAX_MEMORY_SIZE:
-            raise OutOfGasError(
-                f"calldata slice with {start=} {size=} exceeds MAX_MEMORY_SIZE"
-            )
+            raise OutOfGasError(f"calldata read {start=} {size=} > MAX_MEMORY_SIZE")
 
         return self.data.slice(start=start, stop=start + size)
 
@@ -689,9 +687,7 @@ class Contract:
     def slice(self, start, size) -> ByteVec:
         # large start is allowed, but we must check the size
         if size > MAX_MEMORY_SIZE:
-            raise OutOfGasError(
-                f"code slice with {start=} {size=} exceeds MAX_MEMORY_SIZE"
-            )
+            raise OutOfGasError(f"code read {start=} {size=} > MAX_MEMORY_SIZE")
 
         stop = start + size
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -483,12 +483,11 @@ class State:
         if not size:
             return ByteVec()
 
-        if loc + size > MAX_MEMORY_SIZE:
-            raise OutOfGasError(
-                f"memory access with {loc=} {size=} exceeds MAX_MEMORY_SIZE"
-            )
+        stop = loc + size
+        if stop > MAX_MEMORY_SIZE:
+            raise OutOfGasError(f"memory read {loc=} {size=} > MAX_MEMORY_SIZE")
 
-        return self.memory.slice(start=loc, stop=loc + size)
+        return self.memory.slice(start=loc, stop=stop)
 
     def set_mslice(self, loc: int, data: ByteVec) -> None:
         """Wraps a memory slice write with a size check."""
@@ -497,12 +496,11 @@ class State:
         if not size:
             return
 
-        if loc + size > MAX_MEMORY_SIZE:
-            raise OutOfGasError(
-                f"memory write with {loc=} {size=} exceeds MAX_MEMORY_SIZE"
-            )
+        stop = loc + size
+        if stop > MAX_MEMORY_SIZE:
+            raise OutOfGasError(f"memory write {loc=} {size=} > MAX_MEMORY_SIZE")
 
-        self.memory.set_slice(start=loc, stop=loc + size, value=data)
+        self.memory.set_slice(start=loc, stop=stop, value=data)
 
     def ret(self, subst: dict = None) -> ByteVec:
         loc: int = self.mloc(subst)

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1680,7 +1680,7 @@
         ],
         "test/MegaMem.t.sol:MegaMemTest": [
             {
-                "name": "check_megaMem_call_in_len(bool)",
+                "name": "check_megaMem_call_in_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1689,7 +1689,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_call_in_ptr(bool)",
+                "name": "check_megaMem_call_in_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1698,7 +1698,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_call_out_len(bool)",
+                "name": "check_megaMem_call_out_len_ok()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1707,7 +1707,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_call_out_ptr(bool)",
+                "name": "check_megaMem_call_out_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1716,7 +1716,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_calldatacopy_dst_ptr(bool)",
+                "name": "check_megaMem_calldatacopy_dst_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1725,7 +1725,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_calldatacopy_src_len(bool)",
+                "name": "check_megaMem_calldatacopy_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1734,7 +1734,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_calldatacopy_src_ptr(bool)",
+                "name": "check_megaMem_calldatacopy_src_ptr_ok()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1743,7 +1743,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_calldataload(bool)",
+                "name": "check_megaMem_calldataload_ok()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1752,7 +1752,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_codecopy_dst_ptr(bool)",
+                "name": "check_megaMem_codecopy_dst_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1761,7 +1761,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_codecopy_src_len(bool)",
+                "name": "check_megaMem_codecopy_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1770,7 +1770,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_codecopy_src_ptr(bool)",
+                "name": "check_megaMem_codecopy_src_ptr_ok()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1779,7 +1779,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_create2_src_len(bool)",
+                "name": "check_megaMem_create2_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1788,7 +1788,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_create2_src_ptr(bool)",
+                "name": "check_megaMem_create2_src_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1797,7 +1797,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_create_src_len(bool)",
+                "name": "check_megaMem_create_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1806,7 +1806,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_create_src_ptr(bool)",
+                "name": "check_megaMem_create_src_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1815,7 +1815,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_extcodecopy_dst_ptr(bool)",
+                "name": "check_megaMem_extcodecopy_dst_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1824,7 +1824,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_extcodecopy_src_len(bool)",
+                "name": "check_megaMem_extcodecopy_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1833,7 +1833,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_extcodecopy_src_ptr(bool)",
+                "name": "check_megaMem_extcodecopy_src_ptr_ok()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1842,7 +1842,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_keccak256_len(bool)",
+                "name": "check_megaMem_keccak256_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1851,7 +1851,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_keccak256_ptr(bool)",
+                "name": "check_megaMem_keccak256_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1860,7 +1860,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_log0_len(bool)",
+                "name": "check_megaMem_log0_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1869,7 +1869,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_log0_ptr(bool)",
+                "name": "check_megaMem_log0_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1878,7 +1878,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_mcopy_dst_ptr(bool)",
+                "name": "check_megaMem_mcopy_dst_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1887,7 +1887,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_mcopy_src_len(bool)",
+                "name": "check_megaMem_mcopy_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1896,7 +1896,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_mcopy_src_ptr(bool)",
+                "name": "check_megaMem_mcopy_src_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1905,7 +1905,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_mload(bool)",
+                "name": "check_megaMem_mload_src_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1914,7 +1914,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_mstore(bool)",
+                "name": "check_megaMem_mstore8_dst_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1923,7 +1923,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_mstore8(bool)",
+                "name": "check_megaMem_mstore_dst_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1932,7 +1932,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_new_bytes(bool)",
+                "name": "check_megaMem_new_bytes_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1941,7 +1941,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_return_len(bool)",
+                "name": "check_megaMem_return_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1950,7 +1950,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_return_ptr(bool)",
+                "name": "check_megaMem_return_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1959,7 +1959,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_returndatacopy_dst_ptr(bool)",
+                "name": "check_megaMem_returndatacopy_dst_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1968,7 +1968,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_returndatacopy_src_len(bool)",
+                "name": "check_megaMem_returndatacopy_src_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1977,7 +1977,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_returndatacopy_src_ptr(bool)",
+                "name": "check_megaMem_returndatacopy_src_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1986,7 +1986,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_revert_len(bool)",
+                "name": "check_megaMem_revert_len_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1995,7 +1995,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_revert_ptr(bool)",
+                "name": "check_megaMem_revert_ptr_reverts()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1689,7 +1689,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_call_in_ptr_reverts()",
+                "name": "check_megaMem_call_in_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1707,7 +1707,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_call_out_ptr_reverts()",
+                "name": "check_megaMem_call_out_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -1851,7 +1851,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_megaMem_keccak256_ptr_reverts()",
+                "name": "check_megaMem_keccak256_ptr_reverts(bool)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1678,6 +1678,332 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/MegaMem.t.sol:MegaMemTest": [
+            {
+                "name": "check_megaMem_call_in_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_call_in_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_call_out_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_call_out_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_calldatacopy_dst_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_calldatacopy_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_calldatacopy_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_calldataload(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_codecopy_dst_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_codecopy_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_codecopy_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_create2_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_create2_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_create_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_create_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_extcodecopy_dst_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_extcodecopy_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_extcodecopy_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_keccak256_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_keccak256_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_log0_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_log0_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_mcopy_dst_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_mcopy_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_mcopy_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_mload(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_mstore(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_mstore8(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_new_bytes(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_return_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_return_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_returndatacopy_dst_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_returndatacopy_src_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_returndatacopy_src_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_revert_len(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_megaMem_revert_ptr(bool)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/Natspec.t.sol:NatspecTestContract": [
             {
                 "name": "check_Loop3(uint256)",

--- a/tests/regression/foundry.toml
+++ b/tests/regression/foundry.toml
@@ -5,6 +5,8 @@ libs = ['../lib', 'lib']
 
 evm_version = 'cancun'
 
+optimizer = true
+
 force = false
 # compile options used by halmos (to prevent unnecessary recompilation when running forge test and halmos together)
 extra_output = ["storageLayout", "metadata"]

--- a/tests/regression/test/MegaMem.t.sol
+++ b/tests/regression/test/MegaMem.t.sol
@@ -76,10 +76,13 @@ contract MegaMemTest is Test, SymTest {
         }
     }
 
-    function keccak256_op(uint256 ptr, uint256 len) public pure {
+
+    function keccak256_op(uint256 ptr, uint256 len) public pure returns (bytes32) {
+        bytes32 hash;
         assembly {
-            let hash := keccak256(ptr, len)
+            hash := keccak256(ptr, len)
         }
+        return hash;
     }
 
     function mcopy(uint256 dst_ptr, uint256 src_ptr, uint256 src_len) public pure {

--- a/tests/regression/test/MegaMem.t.sol
+++ b/tests/regression/test/MegaMem.t.sol
@@ -177,11 +177,15 @@ contract MegaMemTest is Test, SymTest {
         }
     }
 
-    function check_megaMem_keccak256_ptr_reverts() external view {
-        try this.keccak256_op(BIG_PTR, 32) {
-            assert(false);
+    function check_megaMem_keccak256_ptr_reverts(bool coinflip) external view {
+        uint256 src_len = coinflip ? 0 : 1;
+
+        try this.keccak256_op(BIG_PTR, src_len) {
+            // ok if src_len == 0
+            assertEq(src_len, 0);
         } catch {
-            // success
+            // reverts if src_len > 0
+            assertGt(src_len, 0);
         }
     }
 

--- a/tests/regression/test/MegaMem.t.sol
+++ b/tests/regression/test/MegaMem.t.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {SymTest} from "halmos-cheatcodes/SymTest.sol";
+
+/// @dev This checks that halmos can handle large memory operations without raising
+/// internal errors like "cannot fit 'int' into an index-sized integer".
+/// Instead, we should catch the error and revert the current path, but letting other
+/// paths continue. This is why these tests do a symbolic coinflip, we case split:
+/// - a normal, non-problematic path
+/// - a problematic path with large memory indices or sizes
+/// and we just check that the problematic path does not lead to a failed test
+contract MegaMemTest is Test, SymTest {
+    uint256 MEGA_SIZE = 10 ** 32;
+
+    function setUp() public {
+        // blank
+    }
+
+    /// HELPERS
+
+    function _call(uint256 in_ptr, uint256 in_len, uint256 out_ptr, uint256 out_len) internal {
+        address addr = address(this);
+        uint256 value = 0;
+        bool success;
+        assembly {
+            success := call(gas(), addr, value, in_ptr, in_len, out_ptr, out_len)
+        }
+    }
+
+    function _keccak256(uint256 ptr, uint256 len) internal pure {
+        assembly {
+            let hash := keccak256(ptr, len)
+        }
+    }
+
+    function _mcopy(uint256 dst_ptr, uint256 src_ptr, uint256 src_len) internal pure {
+        assembly {
+            mcopy(dst_ptr, src_ptr, src_len)
+        }
+    }
+
+    function _return(uint256 ptr, uint256 len) internal pure {
+        assembly {
+            return(ptr, len)
+        }
+    }
+
+    function _revert(uint256 ptr, uint256 len) internal pure {
+        assembly {
+            revert(ptr, len)
+        }
+    }
+
+    function _log0(uint256 ptr, uint256 len) internal {
+        assembly {
+            log0(ptr, len)
+        }
+    }
+
+    function _returndatacopy(uint256 dst_ptr, uint256 src_ptr, uint256 src_len) internal pure {
+        assembly {
+            returndatacopy(dst_ptr, src_ptr, src_len)
+        }
+    }
+
+    function _calldatacopy(uint256 dst_ptr, uint256 src_ptr, uint256 src_len) internal pure {
+        assembly {
+            calldatacopy(dst_ptr, src_ptr, src_len)
+        }
+    }
+
+    function _codecopy(uint256 dst_ptr, uint256 src_ptr, uint256 src_len) internal pure {
+        assembly {
+            codecopy(dst_ptr, src_ptr, src_len)
+        }
+    }
+
+    function _extcodecopy(uint256 dst_ptr, uint256 src_ptr, uint256 src_len) internal view {
+        assembly {
+            extcodecopy(address(), dst_ptr, src_ptr, src_len)
+        }
+    }
+
+    function _create(uint256 src_ptr, uint256 src_len) internal {
+        uint256 value = 0;
+        assembly {
+            let addr := create(value, src_ptr, src_len)
+        }
+    }
+
+    function _create2(uint256 src_ptr, uint256 src_len) internal {
+        uint256 value = 0;
+        uint256 salt = 0;
+        assembly {
+            let addr := create2(value, src_ptr, src_len, salt)
+        }
+    }
+
+    /// @dev just return some data, so that returndatacopy can be tested
+    function dummy() public pure returns(uint256) {
+        return 42;
+    }
+
+    /// @dev public wrapper for revert, so that we can call it and check the return value
+    function just_revert(uint256 ptr, uint256 len) public pure {
+        _revert(ptr, len);
+    }
+
+    /// TESTS
+
+    function check_megaMem_new_bytes(bool coinflip) external view returns (bytes memory) {
+        return new bytes(coinflip ? MEGA_SIZE : 32);
+    }
+
+    function check_megaMem_keccak256_ptr(bool coinflip) external view {
+        _keccak256({ptr: coinflip ? MEGA_SIZE : 0, len: 32});
+    }
+
+    function check_megaMem_keccak256_len(bool coinflip) external view {
+        _keccak256({ptr: 0, len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_call_in_ptr(bool coinflip) external {
+        _call({in_ptr: coinflip ? MEGA_SIZE : 0, in_len: 32, out_ptr: 0, out_len: 32});
+    }
+
+    function check_megaMem_call_in_len(bool coinflip) external {
+        _call({in_ptr: 0, in_len: coinflip ? MEGA_SIZE : 32, out_ptr: 0, out_len: 32});
+    }
+
+    function check_megaMem_call_out_ptr(bool coinflip) external {
+        _call({in_ptr: 0, in_len: 32, out_ptr: coinflip ? MEGA_SIZE : 0, out_len: 32});
+    }
+
+    function check_megaMem_call_out_len(bool coinflip) external {
+        _call({in_ptr: 0, in_len: 32, out_ptr: 0, out_len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_mcopy_dst_ptr(bool coinflip) external view {
+        _mcopy({dst_ptr: coinflip ? MEGA_SIZE : 0, src_ptr: 0, src_len: 1});
+    }
+
+    function check_megaMem_mcopy_src_ptr(bool coinflip) external view {
+        _mcopy({dst_ptr: 0, src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 1});
+    }
+
+    function check_megaMem_mcopy_src_len(bool coinflip) external view {
+        _mcopy({dst_ptr: 0, src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 1});
+    }
+
+    function check_megaMem_return_ptr(bool coinflip) external view returns (bytes memory) {
+        _return({ptr: coinflip ? MEGA_SIZE : 0, len: 32});
+    }
+
+    function check_megaMem_return_len(bool coinflip) external view returns (bytes memory) {
+        _return({ptr: 0, len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_log0_ptr(bool coinflip) external {
+        _log0({ptr: coinflip ? MEGA_SIZE : 0, len: 32});
+    }
+
+    function check_megaMem_log0_len(bool coinflip) external {
+        _log0({ptr: 0, len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_mstore(bool coinflip) external view {
+        uint256 loc = coinflip ? MEGA_SIZE : 0;
+        assembly {
+            mstore(loc, 42)
+        }
+    }
+
+    function check_megaMem_mstore8(bool coinflip) external view {
+        uint256 loc = coinflip ? MEGA_SIZE : 0;
+        assembly {
+            mstore8(loc, 42)
+        }
+    }
+
+    function check_megaMem_mload(bool coinflip) external view {
+        uint256 loc = coinflip ? MEGA_SIZE : 0;
+        assembly {
+            let x := mload(loc)
+        }
+    }
+
+    function check_megaMem_returndatacopy_dst_ptr(bool coinflip) external view {
+        MegaMemTest(address(this)).dummy();
+        _returndatacopy({dst_ptr: coinflip ? MEGA_SIZE : 0, src_ptr: 0, src_len: 32});
+    }
+
+    function check_megaMem_returndatacopy_src_ptr(bool coinflip) external view {
+        MegaMemTest(address(this)).dummy();
+        _returndatacopy({dst_ptr: 0, src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 32});
+    }
+
+    function check_megaMem_returndatacopy_src_len(bool coinflip) external view {
+        MegaMemTest(address(this)).dummy();
+        _returndatacopy({dst_ptr: 0, src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_revert_ptr(bool coinflip) external view {
+        try this.just_revert({ptr: coinflip ? MEGA_SIZE : 0, len: 32}) {
+            assert(false);
+        } catch {
+            // success
+        }
+    }
+
+    function check_megaMem_revert_len(bool coinflip) external view {
+        try this.just_revert({ptr: 0, len: coinflip ? MEGA_SIZE : 32}) {
+            assert(false);
+        } catch {
+            // success
+        }
+    }
+
+    function check_megaMem_calldatacopy_dst_ptr(bool coinflip) external view {
+        _calldatacopy({dst_ptr: coinflip ? MEGA_SIZE : 0, src_ptr: 0, src_len: 32});
+    }
+
+    function check_megaMem_calldatacopy_src_ptr(bool coinflip) external view {
+        _calldatacopy({dst_ptr: 0, src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 32});
+    }
+
+    function check_megaMem_calldatacopy_src_len(bool coinflip) external view {
+        _calldatacopy({dst_ptr: 0, src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_calldataload(bool coinflip) external view {
+        uint256 loc = coinflip ? MEGA_SIZE : 0;
+        assembly {
+            let x := calldataload(loc)
+        }
+    }
+
+    function check_megaMem_codecopy_dst_ptr(bool coinflip) external view {
+        _codecopy({dst_ptr: coinflip ? MEGA_SIZE : 0, src_ptr: 0, src_len: 32});
+    }
+
+    function check_megaMem_codecopy_src_ptr(bool coinflip) external view {
+        _codecopy({dst_ptr: 0, src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 32});
+    }
+
+    function check_megaMem_codecopy_src_len(bool coinflip) external view {
+        _codecopy({dst_ptr: 0, src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_extcodecopy_dst_ptr(bool coinflip) external view {
+        _extcodecopy({dst_ptr: coinflip ? MEGA_SIZE : 0, src_ptr: 0, src_len: 32});
+    }
+
+    function check_megaMem_extcodecopy_src_ptr(bool coinflip) external view {
+        _extcodecopy({dst_ptr: 0, src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 32});
+    }
+
+    function check_megaMem_extcodecopy_src_len(bool coinflip) external view {
+        _extcodecopy({dst_ptr: 0, src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_create_src_ptr(bool coinflip) external {
+        _create({src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 32});
+    }
+
+    function check_megaMem_create_src_len(bool coinflip) external {
+        _create({src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 32});
+    }
+
+    function check_megaMem_create2_src_ptr(bool coinflip) external {
+        _create2({src_ptr: coinflip ? MEGA_SIZE : 0, src_len: 32});
+    }
+
+    function check_megaMem_create2_src_len(bool coinflip) external {
+        _create2({src_ptr: 0, src_len: coinflip ? MEGA_SIZE : 32});
+    }
+}

--- a/tests/regression/test/MegaMem.t.sol
+++ b/tests/regression/test/MegaMem.t.sol
@@ -57,6 +57,12 @@ contract MegaMemTest is Test, SymTest {
         return val;
     }
 
+    fallback(bytes calldata) external returns (bytes memory) {
+        // just here to make sure we can call this contract with the null selector
+        // without reverting (and with some actual return data)
+        return new bytes(32);
+    }
+
     function new_bytes(uint256 len) public pure returns (bytes memory) {
         return new bytes(len);
     }
@@ -197,11 +203,15 @@ contract MegaMemTest is Test, SymTest {
         }
     }
 
-    function check_megaMem_call_in_ptr_reverts() external {
-        try this.call_op({in_ptr: BIG_PTR, in_len: 32, out_ptr: 0, out_len: 32}) {
-            assert(false);
+    function check_megaMem_call_in_ptr_reverts(bool coinflip) external {
+        uint256 in_len = coinflip ? 1 : 0;
+
+        try this.call_op({in_ptr: BIG_PTR, in_len: in_len, out_ptr: 0, out_len: 32}) {
+            // ok if in_len == 0
+            assertEq(in_len, 0);
         } catch {
-            // success
+            // reverts if in_len > 0
+            assertGt(in_len, 0);
         }
     }
 
@@ -213,11 +223,15 @@ contract MegaMemTest is Test, SymTest {
         }
     }
 
-    function check_megaMem_call_out_ptr_reverts() external {
-        try this.call_op({in_ptr: 0, in_len: 32, out_ptr: BIG_PTR, out_len: 32}) {
-            assert(false);
+    function check_megaMem_call_out_ptr_reverts(bool coinflip) external {
+        uint256 out_len = coinflip ? 1 : 0;
+
+        try this.call_op({in_ptr: 0, in_len: 32, out_ptr: BIG_PTR, out_len: out_len}) {
+            // ok if out_len == 0
+            assertEq(out_len, 0);
         } catch {
-            // success
+            // reverts if out_len > 0
+            assertGt(out_len, 0);
         }
     }
 


### PR DESCRIPTION
these can otherwise raise `OverflowError: cannot fit 'int' into an index-sized integer`

For example:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.15;

import "forge-std/Test.sol";
import {console2} from "forge-std/console2.sol";

import {SymTest} from "halmos-cheatcodes/SymTest.sol";

contract Test112 is Test, SymTest {
    uint256 MEGA_SIZE = 10**32;

    function setUp() public {
        console2.log("Test112.setUp");
    }

    // good: reverts with Panic(0x41) (too much memory requested)
    function test_megaMem_new_bytes() external {
        bytes memory data = new bytes(MEGA_SIZE);
        console2.logBytes(data);
    }

    // bad: OverflowError: cannot fit 'int' into an index-sized integer
    function test_megaMem_sha3() external {
        bytes32 hash;
        uint256 size = MEGA_SIZE;
        assembly {
            hash := keccak256(0, size)
        }
    }

    function test_megaMem_call_insize() external {
        address addr = address(this);
        uint256 value = 0;
        bool success;
        uint256 in_ptr = 0;
        uint256 in_size = MEGA_SIZE;
        uint256 out_ptr = 0;
        uint256 out_size = 0;

        assembly {
            success := call(gas(), addr, value, in_ptr, in_size, out_ptr, out_size)
        }
    }

    // PASS
    function test_megaMem_call_outsize() external {
        address addr = address(this);
        uint256 value = 0;
        bool success;
        uint256 in_ptr = 0;
        uint256 in_size = 0;
        uint256 out_ptr = 0;
        uint256 out_size = MEGA_SIZE;

        assembly {
            success := call(gas(), addr, value, in_ptr, in_size, out_ptr, out_size)
        }
    }

    function test_megaMem_return() external returns (bytes memory) {
        uint256 size = MEGA_SIZE;
        assembly {
            return(0, size)
        }
    }

    function test_megaMem_log() external {
        uint256 size = MEGA_SIZE;
        assembly {
            log0(0, size)
        }
    }
}
```