### PR TITLE
Fix spellings in `sevm.py` and `mapper.py`

### DIFF
--- a/src/halmos/mapper.py
+++ b/src/halmos/mapper.py
@@ -274,7 +274,7 @@ class Mapper(metaclass=SingletonMeta):
         # }
 
         for contract_mapping_info in self._contracts.values():
-            # TODO: use regex instaed of `endswith` to better handle immutables or constructors with arguments
+            # TODO: use regex instead of `endswith` to better handle immutables or constructors with arguments
             if contract_mapping_info.bytecode.endswith(bytecode):
                 return contract_mapping_info
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2797,7 +2797,7 @@ class SEVM:
                     ex.path.activate()
 
                 # PathEndingException may not be immediately raised; it could be delayed until it comes out of the worklist
-                # see the assert cheatcode hanlder logic for the delayed case
+                # see the assert cheatcode handler logic for the delayed case
                 if isinstance(ex.context.output.error, PathEndingException):
                     raise ex.context.output.error
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1215,7 +1215,7 @@ class Exec:  # an execution path
         assert_address(addr)
         addr = uint160(addr)
         value = self.select(self.balance, addr, self.balances)
-        # generate emptyness axiom for each array index, instead of using quantified formula
+        # generate emptiness axiom for each array index, instead of using quantified formula
         self.path.append(Select(EMPTY_BALANCE, addr) == ZERO)
         # practical assumption on the max balance per account
         self.path.append(ULT(value, con(2**96)))
@@ -1456,7 +1456,7 @@ class SolidityStorage(Storage):
 
         if size_keys > 0:
             # do not use z3 const array `K(BitVecSort(size_keys), ZERO)` when not ex.symbolic
-            # instead use normal smt array, and generate emptyness axiom; see load()
+            # instead use normal smt array, and generate emptiness axiom; see load()
             storage[slot, num_keys, size_keys] = cls.empty(addr, slot, keys)
             return
 
@@ -1487,7 +1487,7 @@ class SolidityStorage(Storage):
         concat_keys = concat(keys)
 
         if not symbolic:
-            # generate emptyness axiom for each array index, instead of using quantified formula; see init()
+            # generate emptiness axiom for each array index, instead of using quantified formula; see init()
             default_value = Select(cls.empty(addr, slot, keys), concat_keys)
             ex.path.append(default_value == ZERO)
 
@@ -1633,7 +1633,7 @@ class GenericStorage(Storage):
         symbolic = storage.symbolic
 
         if not symbolic:
-            # generate emptyness axiom for each array index, instead of using quantified formula; see init()
+            # generate emptiness axiom for each array index, instead of using quantified formula; see init()
             default_value = Select(cls.empty(addr, loc), loc)
             ex.path.append(default_value == ZERO)
 
@@ -2075,10 +2075,10 @@ class SEVM:
                 )
                 potential_aliases.append((addr, alias_cond))
 
-        emptyness_cond = And([target != addr for addr in ex.code])
-        if ex.check(emptyness_cond) != unsat:
+        emptiness_cond = And([target != addr for addr in ex.code])
+        if ex.check(emptiness_cond) != unsat:
             debug_once(f"Potential empty address: {hexify(target)}")
-            potential_aliases.append((None, emptyness_cond))
+            potential_aliases.append((None, emptiness_cond))
 
         if not potential_aliases:
             raise InfeasiblePath("resolve_address_alias: no potential aliases")

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1315,7 +1315,7 @@ class Exec:  # an execution path
         # an injectivity axiom for f_sha3_[size](data) can be formulated as:
         # - there exists f_inv_sha3 such that: f_inv_sha3(f_sha3_[size](data)) == (data, size)
         #
-        # to avoid using a tuple as the return data type, the above can be re-formulated using seperate functions such that:
+        # to avoid using a tuple as the return data type, the above can be re-formulated using separate functions such that:
         # - f_inv_sha3_data(f_sha3_[size](data)) == data
         # - f_inv_sha3_size(f_sha3_[size](data)) == size
         #


### PR DESCRIPTION
1. **`mapper.py`**:
   - Corrected "instaed" to "instead" in a comment about using regex for bytecode handling.

2. **`sevm.py`**:
   - Fixed "emptyness" to "emptiness" in multiple comments related to axiom generation.
   - Corrected "seperate" to "separate" in a comment about tuple reformulation.
   - Fixed "hanlder" to "handler" in a comment about cheatcode logic.
   - Corrected "emptyness_cond" to "emptiness_cond" in a condition for resolving address aliases.
