### PR TITLE
test: disable gc for morpho test

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -22,7 +22,7 @@ jobs:
         project:
           - repo: "morpho-org/morpho-data-structures"
             dir: "morpho-data-structures"
-            cmd: "--function testProve --loop 4 --solver-command yices-smt2 --solver-threads 3"
+            cmd: "--function testProve --loop 4 --solver-command yices-smt2 --solver-threads 3 --disable-gc"
             branch: ""
             profile: ""
           - repo: "morpho-org/morpho-blue"


### PR DESCRIPTION
cyclic gc causes intermittent z3 crashes for morpho tests; disable gc mitigates this issue.
https://github.com/a16z/halmos/actions/runs/13319782425/job/37202780659
