### PR TITLE
feat: support for TLOAD/TSTORE

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -237,6 +237,7 @@ def deploy_test(ctx: FunctionContext, sevm: SEVM) -> Exec:
     ex = sevm.mk_exec(
         code={this: Contract(b"")},
         storage={this: sevm.mk_storagedata()},
+        transient_storage={this: sevm.mk_storagedata()},
         balance=EMPTY_BALANCE,
         block=mk_block(),
         context=CallContext(message=message),
@@ -439,6 +440,7 @@ def run_test(ctx: FunctionContext) -> TestResult:
         Exec(
             code=setup_ex.code.copy(),  # shallow copy
             storage=deepcopy(setup_ex.storage),
+            transient_storage=deepcopy(setup_ex.transient_storage),
             balance=setup_ex.balance,
             #
             block=deepcopy(setup_ex.block),

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2072,7 +2072,7 @@ class SEVM:
         return self.storage_model.mk_storagedata()
 
     def sload(self, ex: Exec, addr: Any, loc: Word, transient: bool = False) -> Word:
-        storage = ex.storage if not transient else ex.transient_storage
+        storage = ex.transient_storage if transient else ex.storage
         val = self.storage_model.load(ex, storage, addr, loc)
         ex.context.trace.append(StorageRead(addr, loc, val, transient))
         return val
@@ -2080,7 +2080,7 @@ class SEVM:
     def sstore(
         self, ex: Exec, addr: Any, loc: Any, val: Any, transient: bool = False
     ) -> None:
-        storage = ex.storage if not transient else ex.transient_storage
+        storage = ex.transient_storage if transient else ex.storage
 
         ex.context.trace.append(StorageWrite(addr, loc, val, transient))
 

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1469,7 +1469,14 @@ class SolidityStorage(Storage):
 
     @classmethod
     def init(
-        cls, ex: Exec, storage: dict, addr: Any, slot: int, keys: tuple, num_keys: int, size_keys: int
+        cls,
+        ex: Exec,
+        storage: dict,
+        addr: Any,
+        slot: int,
+        keys: tuple,
+        num_keys: int,
+        size_keys: int,
     ) -> None:
         """
         Initialize storage[addr].mapping[slot][num_keys][size_keys], if not yet initialized
@@ -1637,7 +1644,9 @@ class GenericStorage(Storage):
         )
 
     @classmethod
-    def init(cls, ex: Exec, storage: dict, addr: Any, loc: BitVecRef, size_keys: int) -> None:
+    def init(
+        cls, ex: Exec, storage: dict, addr: Any, loc: BitVecRef, size_keys: int
+    ) -> None:
         """
         Initialize storage[addr].mapping[size_keys], if not yet initialized
 
@@ -2066,7 +2075,9 @@ class SEVM:
         ex.context.trace.append(StorageRead(addr, loc, val))
         return val
 
-    def sstore(self, ex: Exec, addr: Any, loc: Any, val: Any, transient: bool = False) -> None:
+    def sstore(
+        self, ex: Exec, addr: Any, loc: Any, val: Any, transient: bool = False
+    ) -> None:
         storage = ex.storage if not transient else ex.transient_storage
 
         ex.context.trace.append(StorageWrite(addr, loc, val))
@@ -3167,12 +3178,12 @@ class SEVM:
 
                 elif opcode == EVM.TLOAD:
                     slot: Word = ex.st.pop()
-                    ex.st.push(self.sload(ex, ex.this(), slot, transient = True))
+                    ex.st.push(self.sload(ex, ex.this(), slot, transient=True))
 
                 elif opcode == EVM.TSTORE:
                     slot: Word = ex.st.pop()
                     value: Word = ex.st.pop()
-                    self.sstore(ex, ex.this(), slot, value, transient = True)
+                    self.sstore(ex, ex.this(), slot, value, transient=True)
 
                 elif opcode == EVM.RETURNDATASIZE:
                     ex.st.push(ex.returndatasize())

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -979,6 +979,7 @@ class Exec:  # an execution path
     # network
     code: dict[Address, Contract]
     storage: dict[Address, StorageData]  # address -> { storage slot -> value }
+    transient_storage: dict[Address, StorageData]  # for TLOAD and TSTORE
     balance: Any  # address -> balance
 
     # block
@@ -1010,6 +1011,7 @@ class Exec:  # an execution path
     def __init__(self, **kwargs) -> None:
         self.code = kwargs["code"]
         self.storage = kwargs["storage"]
+        self.transient_storage = kwargs["transient_storage"]
         self.balance = kwargs["balance"]
         #
         self.block = kwargs["block"]
@@ -1150,6 +1152,13 @@ class Exec:  # an execution path
                         map(
                             lambda x: f"- {x}: {self.storage[x]}\n",
                             self.storage,
+                        )
+                    ),
+                    "Transient Storage:\n",
+                    "".join(
+                        map(
+                            lambda x: f"- {x}: {self.transient_storage[x]}\n",
+                            self.transient_storage,
                         )
                     ),
                     f"Path:\n{self.path}",
@@ -1460,50 +1469,50 @@ class SolidityStorage(Storage):
 
     @classmethod
     def init(
-        cls, ex: Exec, addr: Any, slot: int, keys: tuple, num_keys: int, size_keys: int
+        cls, ex: Exec, storage: dict, addr: Any, slot: int, keys: tuple, num_keys: int, size_keys: int
     ) -> None:
         """
-        Initialize ex.storage[addr].mapping[slot][num_keys][size_keys], if not yet initialized
+        Initialize storage[addr].mapping[slot][num_keys][size_keys], if not yet initialized
         - case size_keys == 0: scalar type: initialized with zero or symbolic value
         - case size_keys != 0: mapping type: initialized with empty array or symbolic array
         """
         assert_address(addr)
 
-        storage = ex.storage[addr]
+        storage_addr = storage[addr]
 
-        if (slot, num_keys, size_keys) in storage:
+        if (slot, num_keys, size_keys) in storage_addr:
             return
 
         if size_keys > 0:
             # do not use z3 const array `K(BitVecSort(size_keys), ZERO)` when not ex.symbolic
             # instead use normal smt array, and generate emptyness axiom; see load()
-            storage[slot, num_keys, size_keys] = cls.empty(addr, slot, keys)
+            storage_addr[slot, num_keys, size_keys] = cls.empty(addr, slot, keys)
             return
 
         # size_keys == 0
-        storage[slot, num_keys, size_keys] = (
+        storage_addr[slot, num_keys, size_keys] = (
             BitVec(
                 # note: uuid is excluded to be deterministic
                 f"storage_{id_str(addr)}_{slot}_{num_keys}_{size_keys}_00",
                 BitVecSort256,
             )
-            if storage.symbolic
+            if storage_addr.symbolic
             else ZERO
         )
 
     @classmethod
-    def load(cls, ex: Exec, addr: Any, loc: Word) -> Word:
+    def load(cls, ex: Exec, storage: dict, addr: Any, loc: Word) -> Word:
         (slot, keys, num_keys, size_keys) = cls.get_key_structure(ex, loc)
 
-        cls.init(ex, addr, slot, keys, num_keys, size_keys)
+        cls.init(ex, storage, addr, slot, keys, num_keys, size_keys)
 
-        storage = ex.storage[addr]
-        storage_chunk = storage[slot, num_keys, size_keys]
+        storage_addr = storage[addr]
+        storage_chunk = storage_addr[slot, num_keys, size_keys]
 
         if num_keys == 0:
             return storage_chunk
 
-        symbolic = storage.symbolic
+        symbolic = storage_addr.symbolic
         concat_keys = concat(keys)
 
         if not symbolic:
@@ -1514,15 +1523,15 @@ class SolidityStorage(Storage):
         return ex.select(storage_chunk, concat_keys, ex.storages, symbolic)
 
     @classmethod
-    def store(cls, ex: Exec, addr: Any, loc: Any, val: Any) -> None:
+    def store(cls, ex: Exec, storage: dict, addr: Any, loc: Any, val: Any) -> None:
         (slot, keys, num_keys, size_keys) = cls.get_key_structure(ex, loc)
 
-        cls.init(ex, addr, slot, keys, num_keys, size_keys)
+        cls.init(ex, storage, addr, slot, keys, num_keys, size_keys)
 
-        storage = ex.storage[addr]
+        storage_addr = storage[addr]
 
         if num_keys == 0:
-            storage[slot, num_keys, size_keys] = val
+            storage_addr[slot, num_keys, size_keys] = val
             return
 
         new_storage_var = Array(
@@ -1530,10 +1539,10 @@ class SolidityStorage(Storage):
             BitVecSorts[size_keys],
             BitVecSort256,
         )
-        new_storage = Store(storage[slot, num_keys, size_keys], concat(keys), val)
+        new_storage = Store(storage_addr[slot, num_keys, size_keys], concat(keys), val)
         ex.path.append(new_storage_var == new_storage)
 
-        storage[slot, num_keys, size_keys] = new_storage_var
+        storage_addr[slot, num_keys, size_keys] = new_storage_var
         ex.storages[new_storage_var] = new_storage
 
     @classmethod
@@ -1628,55 +1637,55 @@ class GenericStorage(Storage):
         )
 
     @classmethod
-    def init(cls, ex: Exec, addr: Any, loc: BitVecRef, size_keys: int) -> None:
+    def init(cls, ex: Exec, storage: dict, addr: Any, loc: BitVecRef, size_keys: int) -> None:
         """
-        Initialize ex.storage[addr].mapping[size_keys], if not yet initialized
+        Initialize storage[addr].mapping[size_keys], if not yet initialized
 
         NOTE: unlike SolidityStorage, size_keys > 0 in GenericStorage.
               thus it is of mapping type, and initialized with empty array or symbolic array.
         """
         assert_address(addr)
 
-        storage = ex.storage[addr]
+        storage_addr = storage[addr]
 
-        if size_keys not in storage:
-            storage[size_keys] = cls.empty(addr, loc)
+        if size_keys not in storage_addr:
+            storage_addr[size_keys] = cls.empty(addr, loc)
 
     @classmethod
-    def load(cls, ex: Exec, addr: Any, loc: Word) -> Word:
+    def load(cls, ex: Exec, storage: dict, addr: Any, loc: Word) -> Word:
         loc = cls.decode(loc)
         size_keys = loc.size()
 
-        cls.init(ex, addr, loc, size_keys)
+        cls.init(ex, storage, addr, loc, size_keys)
 
-        storage = ex.storage[addr]
-        symbolic = storage.symbolic
+        storage_addr = storage[addr]
+        symbolic = storage_addr.symbolic
 
         if not symbolic:
             # generate emptyness axiom for each array index, instead of using quantified formula; see init()
             default_value = Select(cls.empty(addr, loc), loc)
             ex.path.append(default_value == ZERO)
 
-        return ex.select(storage[size_keys], loc, ex.storages, symbolic)
+        return ex.select(storage_addr[size_keys], loc, ex.storages, symbolic)
 
     @classmethod
-    def store(cls, ex: Exec, addr: Any, loc: Any, val: Any) -> None:
+    def store(cls, ex: Exec, storage: dict, addr: Any, loc: Any, val: Any) -> None:
         loc = cls.decode(loc)
         size_keys = loc.size()
 
-        cls.init(ex, addr, loc, size_keys)
+        cls.init(ex, storage, addr, loc, size_keys)
 
-        storage = ex.storage[addr]
+        storage_addr = storage[addr]
 
         new_storage_var = Array(
             f"storage_{id_str(addr)}_{size_keys}_{uid()}_{1+len(ex.storages):>02}",
             BitVecSorts[size_keys],
             BitVecSort256,
         )
-        new_storage = Store(storage[size_keys], loc, val)
+        new_storage = Store(storage_addr[size_keys], loc, val)
         ex.path.append(new_storage_var == new_storage)
 
-        storage[size_keys] = new_storage_var
+        storage_addr[size_keys] = new_storage_var
         ex.storages[new_storage_var] = new_storage
 
     @classmethod
@@ -2051,12 +2060,15 @@ class SEVM:
     def mk_storagedata(self) -> StorageData:
         return self.storage_model.mk_storagedata()
 
-    def sload(self, ex: Exec, addr: Any, loc: Word) -> Word:
-        val = self.storage_model.load(ex, addr, loc)
+    def sload(self, ex: Exec, addr: Any, loc: Word, transient: bool = False) -> Word:
+        storage = ex.storage if not transient else ex.transient_storage
+        val = self.storage_model.load(ex, storage, addr, loc)
         ex.context.trace.append(StorageRead(addr, loc, val))
         return val
 
-    def sstore(self, ex: Exec, addr: Any, loc: Any, val: Any) -> None:
+    def sstore(self, ex: Exec, addr: Any, loc: Any, val: Any, transient: bool = False) -> None:
+        storage = ex.storage if not transient else ex.transient_storage
+
         ex.context.trace.append(StorageWrite(addr, loc, val))
 
         if ex.message().is_static:
@@ -2065,7 +2077,7 @@ class SEVM:
         if is_bool(val):
             val = If(val, ONE, ZERO)
 
-        self.storage_model.store(ex, addr, loc, val)
+        self.storage_model.store(ex, storage, addr, loc, val)
 
     def resolve_address_alias(
         self, ex: Exec, target: Address, stack, step_id, allow_branching=True
@@ -2190,6 +2202,7 @@ class SEVM:
             # backup current state
             orig_code = ex.code.copy()
             orig_storage = deepcopy(ex.storage)
+            orig_transient_storage = deepcopy(ex.transient_storage)
             orig_balance = ex.balance
 
             # transfer msg.value
@@ -2239,6 +2252,7 @@ class SEVM:
                     # revert network states
                     new_ex.code = orig_code.copy()
                     new_ex.storage = deepcopy(orig_storage)
+                    new_ex.transient_storage = deepcopy(orig_transient_storage)
                     new_ex.balance = orig_balance
 
                 # add to worklist even if it reverted during the external call
@@ -2248,6 +2262,7 @@ class SEVM:
             sub_ex = Exec(
                 code=ex.code,
                 storage=ex.storage,
+                transient_storage=ex.transient_storage,
                 balance=ex.balance,
                 #
                 block=ex.block,
@@ -2518,6 +2533,7 @@ class SEVM:
         # backup current state
         orig_code = ex.code.copy()
         orig_storage = deepcopy(ex.storage)
+        orig_transient_storage = deepcopy(ex.transient_storage)
         orig_balance = ex.balance
 
         # setup new account
@@ -2525,6 +2541,7 @@ class SEVM:
 
         # existing storage may not be empty and reset here
         ex.storage[new_addr] = self.mk_storagedata()
+        ex.transient_storage[new_addr] = self.mk_storagedata()
 
         # transfer value
         self.transfer_value(ex, pranked_caller, new_addr, value)
@@ -2570,6 +2587,7 @@ class SEVM:
                 # revert network states
                 new_ex.code = orig_code.copy()
                 new_ex.storage = deepcopy(orig_storage)
+                new_ex.transient_storage = deepcopy(orig_transient_storage)
                 new_ex.balance = orig_balance
 
             # add to worklist
@@ -2579,6 +2597,7 @@ class SEVM:
         sub_ex = Exec(
             code=ex.code,
             storage=ex.storage,
+            transient_storage=ex.transient_storage,
             balance=ex.balance,
             #
             block=ex.block,
@@ -2702,6 +2721,7 @@ class SEVM:
         new_ex = Exec(
             code=ex.code.copy(),  # shallow copy for potential new contract creation; existing code doesn't change
             storage=deepcopy(ex.storage),
+            transient_storage=deepcopy(ex.transient_storage),
             balance=ex.balance,
             #
             block=deepcopy(ex.block),
@@ -3145,6 +3165,15 @@ class SEVM:
                     value: Word = ex.st.pop()
                     self.sstore(ex, ex.this(), slot, value)
 
+                elif opcode == EVM.TLOAD:
+                    slot: Word = ex.st.pop()
+                    ex.st.push(self.sload(ex, ex.this(), slot, transient = True))
+
+                elif opcode == EVM.TSTORE:
+                    slot: Word = ex.st.pop()
+                    value: Word = ex.st.pop()
+                    self.sstore(ex, ex.this(), slot, value, transient = True)
+
                 elif opcode == EVM.RETURNDATASIZE:
                     ex.st.push(ex.returndatasize())
 
@@ -3284,6 +3313,7 @@ class SEVM:
         #
         code,
         storage,
+        transient_storage,
         balance,
         #
         block,
@@ -3296,6 +3326,7 @@ class SEVM:
         return Exec(
             code=code,
             storage=storage,
+            transient_storage=transient_storage,
             balance=balance,
             #
             block=block,

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -350,6 +350,7 @@ class StorageWrite:
     address: Address
     slot: Word
     value: Word
+    transient: bool
 
 
 @dataclass(frozen=True)
@@ -357,6 +358,7 @@ class StorageRead:
     address: Address
     slot: Word
     value: Word
+    transient: bool
 
 
 @dataclass(frozen=True)
@@ -2072,7 +2074,7 @@ class SEVM:
     def sload(self, ex: Exec, addr: Any, loc: Word, transient: bool = False) -> Word:
         storage = ex.storage if not transient else ex.transient_storage
         val = self.storage_model.load(ex, storage, addr, loc)
-        ex.context.trace.append(StorageRead(addr, loc, val))
+        ex.context.trace.append(StorageRead(addr, loc, val, transient))
         return val
 
     def sstore(
@@ -2080,7 +2082,7 @@ class SEVM:
     ) -> None:
         storage = ex.storage if not transient else ex.transient_storage
 
-        ex.context.trace.append(StorageWrite(addr, loc, val))
+        ex.context.trace.append(StorageWrite(addr, loc, val, transient))
 
         if ex.message().is_static:
             raise WriteInStaticContext(ex.context_str())

--- a/src/halmos/traces.py
+++ b/src/halmos/traces.py
@@ -114,12 +114,14 @@ def rendered_slot(slot: Address) -> str:
 
 def rendered_sstore(update: StorageWrite) -> str:
     slot_str = rendered_slot(update.slot)
-    return f"{cyan('SSTORE')} @{slot_str} ← {hexify(update.value)}"
+    opcode = cyan("SSTORE" if not update.transient else "TSTORE")
+    return f"{opcode} @{slot_str} ← {hexify(update.value)}"
 
 
 def rendered_sload(read: StorageRead) -> str:
     slot_str = rendered_slot(read.slot)
-    return f"{cyan('SLOAD')}  @{slot_str} → {hexify(read.value)}"
+    opcode = cyan("SLOAD" if not read.transient else "TLOAD")
+    return f"{opcode}  @{slot_str} → {hexify(read.value)}"
 
 
 def rendered_trace(context: CallContext) -> str:

--- a/src/halmos/traces.py
+++ b/src/halmos/traces.py
@@ -114,13 +114,13 @@ def rendered_slot(slot: Address) -> str:
 
 def rendered_sstore(update: StorageWrite) -> str:
     slot_str = rendered_slot(update.slot)
-    opcode = cyan("SSTORE" if not update.transient else "TSTORE")
+    opcode = cyan("TSTORE" if update.transient else "SSTORE")
     return f"{opcode} @{slot_str} ← {hexify(update.value)}"
 
 
 def rendered_sload(read: StorageRead) -> str:
     slot_str = rendered_slot(read.slot)
-    opcode = cyan("SLOAD" if not read.transient else "TLOAD")
+    opcode = cyan("TLOAD" if read.transient else "SLOAD")
     return f"{opcode}  @{slot_str} → {hexify(read.value)}"
 
 

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -669,6 +669,8 @@ class EVM:
     MSIZE = 0x59
     GAS = 0x5A
     JUMPDEST = 0x5B
+    TLOAD = 0x5C
+    TSTORE = 0x5D
     MCOPY = 0x5E
     PUSH0 = 0x5F
     PUSH1 = 0x60
@@ -817,6 +819,9 @@ str_opcode: dict[int, str] = {
     EVM.MSIZE: "MSIZE",
     EVM.GAS: "GAS",
     EVM.JUMPDEST: "JUMPDEST",
+    EVM.TLOAD: "TLOAD",
+    EVM.TSTORE: "TSTORE",
+    EVM.MCOPY: "MCOPY",
     EVM.PUSH0: "PUSH0",
     EVM.PUSH1: "PUSH1",
     EVM.PUSH2: "PUSH2",

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -4496,6 +4496,44 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/TStore.t.sol:TStoreTest": [
+            {
+                "name": "check_sload()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_sstore(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_tload()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_tstore(uint256)",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/TestConstructor.t.sol:TestConstructorTest": [
             {
                 "name": "check_value()",

--- a/tests/regression/test/TStore.t.sol
+++ b/tests/regression/test/TStore.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+contract C {
+    uint public slot0;
+
+    function sstore(uint slot, uint value) public {
+        assembly {
+            sstore(slot, value)
+        }
+    }
+
+    function sload(uint slot) public returns (uint value) {
+        assembly {
+            value := sload(slot)
+        }
+    }
+
+    function tstore(uint slot, uint value) public {
+        assembly {
+            tstore(slot, value)
+        }
+    }
+
+    function tload(uint slot) public returns (uint value) {
+        assembly {
+            value := tload(slot)
+        }
+    }
+}
+
+contract TStoreTest is Test {
+    C c;
+
+    function setUp() public {
+        c = new C();
+    }
+
+    function check_sload() public {
+        assertEq(c.sload(0), 0);
+    }
+
+    function check_tload() public {
+        assertEq(c.tload(0), 0);
+    }
+
+    function check_sstore(uint x) public {
+        c.sstore(0, x);
+        assertEq(c.sload(0), x);
+        assertEq(c.slot0(), x);
+
+        // transient storage isn't affected
+        assertEq(c.tload(0), 0);
+    }
+
+    function check_tstore(uint x) public {
+        c.tstore(0, x);
+        assertEq(c.tload(0), x);
+
+        // persistent storage isn't affected
+        assertEq(c.slot0(), 0);
+        assertEq(c.sload(0), 0);
+    }
+
+    /*
+    function invariant_storage() public {
+        assertEq(c.sload(0), 0); // fail
+    }
+    */
+
+    function invariant_transient_storage() public {
+        // note: transient storage is reset after each tx in the invariant tx sequence
+        assertEq(c.tload(0), 0); // pass
+    }
+}

--- a/tests/test_sevm.py
+++ b/tests/test_sevm.py
@@ -67,6 +67,7 @@ def mk_ex(hexcode, sevm, solver, storage, caller, this):
     return sevm.mk_exec(
         code={this: bytecode},
         storage={this: storage},
+        transient_storage={this: storage},
         balance=balance,
         block=mk_block(),
         context=CallContext(message),


### PR DESCRIPTION
supports for transient storage.

transient storage has its own storage/address space, separate from persistent storage. transient storage behaves the same with persistent storage within a single tx.

since individual tests are executed within a single tx, no separate logic is needed. in the code, two storage objects are created and use the same logic.

todo: for invariant testing, transient storage needs to be reset after each tx.