### PR TITLE
experimental: add flamegraph generation support

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pathlib
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -1181,6 +1182,11 @@ def _main(_args=None) -> MainResult:
         import halmos.memtrace as memtrace
 
         memtrace.MemTracer.get().start()
+
+    if args.flamegraph and not shutil.which("flamegraph.pl"):
+        error("flamegraph.pl not found in PATH")
+        error("(see https://github.com/brendangregg/FlameGraph)")
+        args = args.with_overrides("halmos runtime", flamegraph=False)
 
     #
     # compile

--- a/src/halmos/bitvec.py
+++ b/src/halmos/bitvec.py
@@ -72,7 +72,6 @@ def as_int(value: AnyValue) -> tuple[BVValue, MaybeSize]:
         raise TypeError(f"Cannot convert {type(value)} to int")
 
 
-# TODO: HalmosBool.TRUE, HalmosBool.FALSE
 class HalmosBool:
     """
     Immutable wrapper for concrete or symbolic boolean values.

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -534,10 +534,9 @@ class Config:
         group=experimental,
     )
 
-    coverage_flamegraph: str = arg(
-        help="generate a flamegraph of the execution coverage",
-        global_default=None,
-        metavar="SVG_FILE_PATH",
+    flamegraph: bool = arg(
+        help="generate a flamegraph of the execution",
+        global_default=False,
         group=experimental,
     )
 

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -534,6 +534,13 @@ class Config:
         group=experimental,
     )
 
+    coverage_flamegraph: str = arg(
+        help="generate a flamegraph of the execution coverage",
+        global_default=None,
+        metavar="SVG_FILE_PATH",
+        group=experimental,
+    )
+
     ### Deprecated
 
     test_parallel: bool = arg(

--- a/src/halmos/flamegraphs.py
+++ b/src/halmos/flamegraphs.py
@@ -1,10 +1,51 @@
+import pathlib
 import subprocess
+import threading
+import time
 import traceback
+from dataclasses import dataclass, field
 
 from halmos.logs import debug, warn
 from halmos.sevm import CallContext, CallSequence, Message
 from halmos.traces import rendered_address
 from halmos.utils import hexify
+
+AUTO_REFRESH_INTERVAL_SECONDS = 0.250
+
+
+class TimedThread(threading.Thread):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.start_time = None
+        self.end_time = None
+        self.exception = None
+
+    def run(self):
+        self.start_time = time.perf_counter()
+        try:
+            if self._target:
+                self._target(*self._args, **self._kwargs)
+        except Exception as e:
+            self.exception = e
+        finally:
+            self.end_time = time.perf_counter()
+
+
+def run_with_tmp_output(command: list[str], out_filepath: pathlib.Path) -> None:
+    # first write to a temporary file to avoid corrupting the output file
+    tmp_filepath = out_filepath.with_suffix(".tmp")
+
+    with open(tmp_filepath, "w") as tmp_fd:
+        subprocess.run(
+            command,
+            stdout=tmp_fd,
+            text=True,
+            check=True,  # raise CalledProcessError if the command fails
+        )
+
+    # rename the temporary file to the output file if the command succeeded
+    tmp_filepath.rename(out_filepath)
 
 
 def extract_identifier(message: Message) -> str:
@@ -74,15 +115,24 @@ def extract_sequence(seq: CallSequence, stacks: list[str]) -> list[str]:
     return stacks
 
 
-# TODO: show SSTORE/LOG for stateless flamegraphs
+@dataclass(slots=True, frozen=True, eq=False, order=False)
 class FlamegraphAccumulator:
-    __slots__ = ["title", "colors", "debug", "stacks"]
+    title: str
+    src_filepath: pathlib.Path | None = None
+    out_filepath: pathlib.Path | None = None
 
-    def __init__(self, *, title: str, colors: str = "hot", debug: bool = False):
-        self.title = title
-        self.colors = colors
-        self.debug = debug
-        self.stacks = []
+    colors: str = "hot"
+    stacks: list[str] = field(default_factory=list)
+    auto_flush: bool = False
+    debug: bool = False
+    bg_threads: list[TimedThread] = field(default_factory=list)
+
+    def __post_init__(self):
+        if (src := self.src_filepath) and src.exists():
+            src.unlink()
+
+        if (out := self.out_filepath) and out.exists():
+            out.unlink()
 
     def __len__(self) -> int:
         return len(self.stacks)
@@ -90,41 +140,72 @@ class FlamegraphAccumulator:
     def add(self, call: CallContext):
         extract_stacks(call, self.stacks)
 
-    def generate_flamegraph(self, filename: str) -> None:
-        if not self.stacks:
-            print(f"No stacks collected for {self.title}, ")
+        if self.auto_flush:
+            self.flush()
+
+    def flush(self, force: bool = False) -> None:
+        stacks = self.stacks
+
+        if not stacks:
+            if self.debug:
+                debug(f"No stacks collected for {self.title}, skipping")
             return
 
-        with_counts = "\n".join([f"{line} 1" for line in self.stacks])
+        if not self.src_filepath or not self.out_filepath:
+            raise RuntimeError(f"missing filepath for {self.title}")
 
-        if self.debug:
-            debug(with_counts)
+        with open(self.src_filepath, "a") as src_fd:
+            src_fd.writelines([f"{line} 1\n" for line in stacks])
 
-        try:
-            with open(filename, "w") as f:
-                # stderr not captured, errors will be printed to console
-                stdout = subprocess.check_output(
-                    [
-                        "flamegraph.pl",
-                        "--title",
-                        self.title,
-                        "--colors",
-                        self.colors,
-                    ],
-                    input=with_counts,
-                    text=True,
-                )
-                f.write(stdout)
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            warn(f"Failed to generate flamegraph: {e}")
-            if self.debug:
-                traceback.print_exc()
+        stacks.clear()
+
+        if self.bg_threads:
+            last_thread = self.bg_threads[-1]
+
+            # don't start a new thread if the last one is still running
+            if last_thread.is_alive() or not last_thread.end_time:
+                if force:
+                    last_thread.join()
+                else:
+                    return
+
+            # check if the last thread failed
+            if last_thread.exception:
+                warn(f"Failed to generate flamegraph: {last_thread.exception}")
+                if self.debug:
+                    traceback.print_exc()
+
+            # don't start a new thread if the last one finished recently
+            elapsed = time.perf_counter() - last_thread.end_time
+            if elapsed < AUTO_REFRESH_INTERVAL_SECONDS and not force:
+                return
+
+            self.bg_threads.pop()
+
+        # start flamegraph generation in a background thread
+        command = [
+            "flamegraph.pl",
+            "--title",
+            self.title,
+            "--colors",
+            self.colors,
+            "--cp",
+            str(self.src_filepath),
+        ]
+
+        thread = TimedThread(
+            target=run_with_tmp_output, args=(command, self.out_filepath)
+        )
+        thread.daemon = True
+        thread.start()
+
+        self.bg_threads.append(thread)
+
+        if force:
+            thread.join()
 
 
 class CallSequenceFlamegraph(FlamegraphAccumulator):
-    def __init__(self, *, title: str, colors: str = "aqua", debug: bool = False):
-        super().__init__(title=title, colors=colors, debug=debug)
-
     def add_with_sequence(
         self, seq: CallSequence, call: CallContext, mark_as_fail: bool = False
     ):
@@ -133,9 +214,25 @@ class CallSequenceFlamegraph(FlamegraphAccumulator):
         prefix = ";".join([f"{f.contract_name}::{f.name}" for f in fun_infos])
         extract_stacks(call, self.stacks, prefix=prefix, mark_as_fail=mark_as_fail)
 
+        if self.auto_flush:
+            self.flush()
+
 
 # useful for stateless/single-function tests
-exec_flamegraph = FlamegraphAccumulator(title="Execution Flamegraph")
+exec_flamegraph = FlamegraphAccumulator(
+    title="Execution Flamegraph",
+    src_filepath=pathlib.Path("exec.stacks"),
+    out_filepath=pathlib.Path("exec-flamegraph.svg"),
+    auto_flush=False,
+)
 
 # useful for invariant tests
-call_flamegraph = CallSequenceFlamegraph(title="Call Flamegraph")
+# auto_flush is enabled because invariant tests can be long running and
+# we want to be able to visualize intermediate results
+call_flamegraph = CallSequenceFlamegraph(
+    title="Call Flamegraph",
+    colors="aqua",
+    src_filepath=pathlib.Path("call.stacks"),
+    out_filepath=pathlib.Path("call-flamegraph.svg"),
+    auto_flush=True,
+)

--- a/src/halmos/flamegraphs.py
+++ b/src/halmos/flamegraphs.py
@@ -49,12 +49,12 @@ def extract_stacks(
         prefix: The prefix to add to the stack (optional)
     """
 
-    id = extract_identifier(call.message)
+    identifier = extract_identifier(call.message)
 
     if mark_as_fail:
-        id = f"[FAIL] {id}"
+        identifier = f"[FAIL] {identifier}"
 
-    prefix = f"{prefix};{id}" if prefix else id
+    prefix = f"{prefix};{identifier}" if prefix else identifier
     stacks.append(prefix)
 
     for trace_element in call.trace:

--- a/src/halmos/flamegraphs.py
+++ b/src/halmos/flamegraphs.py
@@ -1,0 +1,117 @@
+import subprocess
+
+from halmos.logs import debug
+from halmos.sevm import CallContext, CallSequence, Message
+from halmos.traces import rendered_address
+from halmos.utils import hexify
+
+
+def extract_identifier(message: Message) -> str:
+    target = rendered_address(message.target)
+
+    if message.is_create():
+        return f"{target}.constructor"
+
+    if (fun_info := message.fun_info) is not None:
+        return f"{fun_info.contract_name}::{fun_info.name}"
+
+    return f"{target}.{hexify(message.data[:4])}"
+
+
+def extract_stacks(
+    ctx: CallContext, stacks: list[str], *, prefix: str = "", mark_as_fail: bool = False
+) -> list[str]:
+    """
+    Expands a call context (i.e. a call tree) into a flat list of stack traces.
+
+    For example, if we have a call tree that looks like this:
+
+        A
+        ├─ B
+        │  └─ D
+        └─ C
+
+    This will be represented as:
+
+        "A"
+        "A;B"
+        "A;B;D"
+        "A;C"
+
+    Parameters:
+        ctx: The call context that will be converted into a collection of stack traces
+        stacks: Where the produced stack traces will be stored (mutable input/output argument)
+        prefix: The prefix to add to the stack (optional)
+    """
+
+    id = extract_identifier(ctx.message)
+
+    if mark_as_fail:
+        id = f"[FAIL] {id}"
+
+    prefix = f"{prefix};{id}" if prefix else id
+    stacks.append(prefix)
+
+    for trace_element in ctx.trace:
+        if isinstance(trace_element, CallContext):
+            extract_stacks(trace_element, stacks, prefix=prefix)
+    return stacks
+
+
+def extract_sequence(seq: CallSequence, stacks: list[str]) -> list[str]:
+    """
+    Extracts a sequence of call contexts into a list of stack traces.
+    """
+
+    for ctx in seq:
+        extract_stacks(ctx, stacks)
+
+    return stacks
+
+
+class FlamegraphAccumulator:
+    stacks: list[str]
+    debug: bool
+
+    def __init__(self, debug: bool = False):
+        self.stacks = []
+        self.debug = True
+
+    def add(self, ctx: CallContext):
+        extract_stacks(ctx, self.stacks)
+
+    def add_with_sequence(
+        self, seq: CallSequence, ctx: CallContext, mark_as_fail: bool = False
+    ):
+        fun_infos = [call_context.message.fun_info for call_context in seq]
+
+        prefix = ";".join([f"{f.contract_name}::{f.name}" for f in fun_infos])
+        extract_stacks(ctx, self.stacks, prefix=prefix, mark_as_fail=mark_as_fail)
+
+    def generate_flamegraph(self, filename: str) -> None:
+        with_counts = "\n".join([f"{line} 1" for line in self.stacks])
+
+        if self.debug:
+            debug(with_counts)
+
+        try:
+            with open(filename, "w") as f:
+                # stderr not captured
+                stdout = subprocess.check_output(
+                    [
+                        "flamegraph.pl",
+                        "--title",
+                        "Exploration Flamegraph",
+                        "--colors",
+                        "aqua",
+                    ],
+                    input=with_counts,
+                    text=True,
+                )
+                f.write(stdout)
+        except subprocess.CalledProcessError as e:
+            if self.debug:
+                raise RuntimeError(f"Failed to generate flamegraph: {e}") from e
+
+
+flamegraph = FlamegraphAccumulator()

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -1297,7 +1297,7 @@ def format_time(seconds: float) -> str:
         return f"{seconds * 1e9:.3f}ns"
 
 
-class timed:
+class timed_block:
     def __init__(self, label="Block"):
         self.label = label
 
@@ -1309,3 +1309,29 @@ class timed:
         end = timer()
         elapsed = end - self.start
         print(f"{self.label} took {format_time(elapsed)}")
+
+
+def timed(label=None):
+    """
+    A decorator that measures and prints the execution time of a function.
+
+    Args:
+        label (str, optional): Custom label for the timing output. If None, the function name will be used.
+
+    Returns:
+        callable: The wrapped function with timing functionality.
+    """
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            # Use function name if no label is provided
+            function_label = label if label is not None else func.__name__
+
+            with timed_block(function_label):
+                result = func(*args, **kwargs)
+
+            return result
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
This supports generating 2 kinds of flamegraphs, enabled with the `--flamegraph` option
- `exec-flamegraph.svg`: renders all paths from all tests 
- `call-flamegraph.svg`: renders call sequences and failed invariant checks

Examples: 

- execution flamegraph from tests/regression:
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/1b58ff33-820e-406b-99ea-fd880db141fc" />

- call flamegraph for `VatTest`:
<img width="1787" alt="image" src="https://github.com/user-attachments/assets/e5522db8-cbf9-4bac-9cb5-d384c269e806" />
<img width="1326" alt="image" src="https://github.com/user-attachments/assets/aa095f8d-edc6-4ad2-a65f-bf36eaf95b92" />

- call flamegraph for `HardMaze`: 
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/637ec855-f98f-46ed-8911-5a1f29f3b323" />

**UPDATE:** Some additional goodies below

## Differential Flamegraphs

```
# run 1, generates call.stacks and call-flamegraph.svg
halmos --flamegraph
mv call.stacks old.stacks

# run 2
halmos --flamegraph
mv call.stacks new.stacks

difffolded.pl old.stacks new.stacks | flamegraph.pl > diff.svg
```

Shows increases in red and decreases in blue between the first and the second run. Can potentially translate to increased/decreased coverage. For instance if we added a public function that can be reached during invariant testing, we expect to see it in red in the flamegraph diff (see https://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html).

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/8e11e788-0c9d-4c52-9a67-7cc51be65ed9" />


## Live Reloads

Because invariant runs can run a long time and may be interrupted, we don't want to wait until the end of the run to render the flamegraphs. So in [2201c98](https://github.com/a16z/halmos/pull/489/commits/2201c984611ea2f2dc0fccd06a2c60d43fb10178) we added on-the-fly generation: we periodically write the folded call stacks to `call.stacks` and invoke `flamegraph.pl` on it to render `call-flamegraph.svg`. So it is possible to live reload `call-flamegraph.svg` to visualize the execution as it happens:

```
# in one shell:
halmos --function invariant_XYZ --flamegraph

# in another shell:
npx live-server call-flamegraph.svg
```

This will open a browser window that will auto-refresh whenever a new version of `call-flamegraph.svg` is generated.

![flamegraphs](https://github.com/user-attachments/assets/91764d7c-8cba-4e8c-9c4a-0dd9fd9dad58)

