### PR TITLE
feat: add --solver <name> command, download on demand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      HALMOS_ALLOW_DOWNLOAD: 1
 
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "rich>=13.9.4",
     "xxhash>=3.5.0",
     "psutil>=6.1.0",
+    "requests>=2.32.3",
 ]
 dynamic = ["version"]
 

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -479,6 +479,14 @@ class Config:
 
     ### Solver options
 
+    solver: str = arg(
+        help="specify the SMT solver to use (e.g., 'yices'). If not specified, defaults to 'z3'. If --solver-command is used, this is ignored.",
+        global_default="z3",
+        metavar="SOLVER_NAME",
+        choices=["yices", "z3"],
+        group=solver,
+    )
+
     smt_exp_by_const: int = arg(
         help="interpret constant power up to N",
         global_default=2,
@@ -508,8 +516,8 @@ class Config:
     )
 
     solver_command: str = arg(
-        help="use the given command when invoking the solver",
-        global_default=str(find_z3_path()),
+        help="use the given exact command when invoking the solver (overrides automatic solver detection/download triggered by --solver)",
+        global_default=None,
         metavar="COMMAND",
         group=solver,
     )

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -7,7 +7,6 @@ from collections.abc import Callable, Generator
 from dataclasses import MISSING, dataclass, fields
 from dataclasses import field as dataclass_field
 from enum import Enum
-from pathlib import Path
 from typing import Any
 
 import toml
@@ -31,29 +30,6 @@ class TraceEvent(Enum):
     LOG = "LOG"
     SSTORE = "SSTORE"
     SLOAD = "SLOAD"
-
-
-def find_venv_root() -> Path | None:
-    # If the environment variable is set, use that
-    if "VIRTUAL_ENV" in os.environ:
-        return Path(os.environ["VIRTUAL_ENV"])
-
-    # Otherwise, if we're in a venv, sys.prefix != sys.base_prefix
-    if sys.prefix != sys.base_prefix:
-        return Path(sys.prefix)
-
-    # Not in a virtual environment
-    return None
-
-
-def find_z3_path() -> Path | None:
-    venv_path = find_venv_root()
-    if venv_path:
-        z3_bin = "z3.exe" if sys.platform == "win32" else "z3"
-        z3_path = venv_path / "bin" / z3_bin
-        if z3_path.exists():
-            return z3_path
-    return None
 
 
 # helper to define config fields

--- a/src/halmos/solve.py
+++ b/src/halmos/solve.py
@@ -402,8 +402,13 @@ def solve_low_level(path_ctx: PathContext) -> SolverOutput:
     # which translates to timeout_seconds=None for subprocess.run
     timeout_seconds = t / 1000 if (t := args.solver_timeout_assertion) else None
 
-    cmd = args.solver_command.split() + [smt2_filename]
-    future = PopenFuture(cmd, timeout=timeout_seconds)
+    cmd_list = (
+        args.solver_command.split()
+        if isinstance(args.solver_command, str)
+        else args.solver_command
+    )
+    cmd_with_file = cmd_list + [smt2_filename]
+    future = PopenFuture(cmd_with_file, timeout=timeout_seconds)
 
     # starts the subprocess asynchronously
     path_ctx.solving_ctx.executor.submit(future)

--- a/src/halmos/solve.py
+++ b/src/halmos/solve.py
@@ -264,9 +264,6 @@ class SolverOutput:
             case "unknown":
                 return SolverOutput(unknown, returncode, path_id)
             case _:
-                print(f"{stdout=}")
-                print(f"{stderr=}")
-                print(f"{returncode=}")
                 return SolverOutput("err", returncode, path_id, error=stderr)
 
 

--- a/src/halmos/solvers.py
+++ b/src/halmos/solvers.py
@@ -207,8 +207,9 @@ def install_solver(solver_info: SolverInfo) -> Path:
         machine_tuple = get_platform_arch()
         download_info = solver_info.downloads.get(machine_tuple)
         if not download_info:
-            raise ValueError(
-                f"No download URL configured for solver '{solver_info.name}'"
+            solver = solver_info.name
+            raise RuntimeError(
+                f"No download URL configured {solver=}, {machine_tuple=}"
             )
 
         # Download the archive

--- a/src/halmos/solvers.py
+++ b/src/halmos/solvers.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import requests
+from rich.console import Console
 
 from halmos.logs import debug, error, info
 from halmos.utils import format_size
@@ -24,6 +25,8 @@ SOLVER_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 # environment variable to bypass the interactive download confirmation prompt
 ALLOW_DOWNLOAD_VAR = "HALMOS_ALLOW_DOWNLOAD"
+
+console = Console()
 
 
 def yices_base_url(version: str) -> str:
@@ -253,7 +256,7 @@ def download_allowed(solver: SolverInfo, download_info: DownloadInfo) -> bool:
     Checks if the download is allowed.
     """
 
-    if not sys.stdout.isatty():
+    if not console.is_interactive:
         return os.environ.get(ALLOW_DOWNLOAD_VAR, "false").lower() in ["true", "1"]
 
     prompt = f"{solver.name} can be downloaded from {download_info.base_url}, ok to proceed? (y/N) "

--- a/src/halmos/solvers.py
+++ b/src/halmos/solvers.py
@@ -1,0 +1,421 @@
+import hashlib
+import os
+import platform
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+from halmos.logs import debug, error, info, warn
+
+# Define the cache directory for solvers
+SOLVER_CACHE_DIR = Path.home() / ".halmos" / "solvers"
+SOLVER_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+YICES_BASE_URL = "https://github.com/SRI-CSL/yices2/releases/download/Yices-2.6.5"
+
+
+@dataclass(frozen=True, eq=True, order=False, slots=True, kw_only=True)
+class MachineInfo:
+    system: str
+    machine: str
+
+
+@dataclass(frozen=True, eq=False, order=False, slots=True)
+class DownloadInfo:
+    base_url: str
+    filename: str
+    checksum: str
+    binary_name_in_archive: str
+
+
+@dataclass(frozen=True, eq=False, order=False, slots=True)
+class SolverInfo:
+    name: str
+
+    # maps (system, machine) tuples to download URLs
+    downloads: dict[MachineInfo, DownloadInfo]
+
+    # options/arguments/flags needed for this solver
+    arguments: list[str]
+
+    # name of the final binary file in the cache
+    binary_name_in_cache: str = ""  # defaults to binary_name_in_archive if empty
+
+
+macos_intel = MachineInfo(system="Darwin", machine="x86_64")
+macos_arm64 = MachineInfo(system="Darwin", machine="arm64")
+linux_intel = MachineInfo(system="Linux", machine="x86_64")
+windows_intel = MachineInfo(system="Windows", machine="x86_64")
+
+# define known solvers
+SUPPORTED_SOLVERS: dict[str, SolverInfo] = {
+    "yices": SolverInfo(
+        name="yices",
+        downloads={
+            macos_intel: DownloadInfo(
+                base_url=YICES_BASE_URL,
+                filename="yices-2.6.5-x86_64-apple-darwin21.6.0-static-gmp.tar.gz",
+                checksum="831094681703173cb30657e9a9d690bd6139f435ff44afdcf81f8e761f9ed0c4",
+                binary_name_in_archive="yices-2.6.5/bin/yices-smt2",
+            ),
+            macos_arm64: DownloadInfo(
+                base_url=YICES_BASE_URL,
+                filename="yices-2.6.5-arm-apple-darwin22.6.0-static-gmp.tar.gz",
+                checksum="b75f2881859fb91c1e8fae121595091b89c07421f35db0e7cddc8a43cba13507",
+                binary_name_in_archive="yices-2.6.5/bin/yices-smt2",
+            ),
+            linux_intel: DownloadInfo(
+                base_url=YICES_BASE_URL,
+                filename="yices-2.6.5-x86_64-pc-linux-gnu-static-gmp.tar.gz",
+                checksum="d6c9465c261e4f4eabd240d0dd9dff5e740fca2beb0042de15f67954bbc70cce",
+                binary_name_in_archive="yices-2.6.5/bin/yices-smt2",
+            ),
+            windows_intel: DownloadInfo(
+                base_url=YICES_BASE_URL,
+                filename="yices-2.6.5-x86_64-unknown-mingw32-static-gmp.zip",
+                checksum="189aaa5515bb71c18996b87d7eceb8cfa037a7b2114f6b46abf5c6f4f07072af",
+                binary_name_in_archive="yices-2.6.5/bin/yices-smt2.exe",
+            ),
+        },
+        binary_name_in_archive="yices-2.6.5/bin/yices-smt2",
+        binary_name_in_cache="yices",
+        arguments=["--smt2-model-format"],
+    ),
+    # for z3 we just rely on PATH/venv
+    "z3": SolverInfo(
+        name="z3",
+        downloads={},
+        binary_name_in_archive="z3",
+        arguments=[],
+    ),
+}
+
+
+def get_platform_arch() -> MachineInfo:
+    """Gets the current OS platform and architecture."""
+
+    system = platform.system()  # e.g., 'Linux', 'Darwin', 'Windows'
+    machine = platform.machine()  # e.g., 'x86_64', 'arm64', 'AMD64'
+
+    return MachineInfo(system=system, machine=machine)
+
+
+def _verify_checksum(file_path: Path, expected_checksum: str) -> bool:
+    """Verifies the SHA256 checksum of a file."""
+
+    sha256_hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        # Read and update hash string value in blocks of 4K
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    calculated_checksum = sha256_hash.hexdigest()
+    if calculated_checksum != expected_checksum:
+        warn(
+            f"Checksum mismatch for {file_path}: Expected {expected_checksum}, Got {calculated_checksum}"
+        )
+        return False
+    debug(f"Checksum verified for {file_path}")
+    return True
+
+
+def _download(
+    download_info: DownloadInfo, output_dir: Path, timeout_seconds: int = 10
+) -> Path | None:
+    """
+    Downloads the solver archive.
+
+    May throw requests.exceptions.RequestException
+    """
+
+    url = download_info.base_url + "/" + download_info.filename
+    response = requests.get(url, stream=True, timeout=timeout_seconds)
+    response.raise_for_status()
+    archive_path = output_dir / download_info.filename
+
+    with open(archive_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+    return archive_path
+
+
+def _list_archive(archive_path: Path) -> None:
+    """Lists the contents of the solver archive."""
+
+    if archive_path.name.endswith(".tar.gz"):
+        with tarfile.open(archive_path, "r:gz") as tar:
+            # list contents
+            for member in tar.getmembers():
+                # locate executable files
+                executable = (
+                    member.mode & stat.S_IXUSR != 0 and member.type == tarfile.REGTYPE
+                )
+
+                print(f"{'* ' if executable else '  '}{member.name}")
+
+    elif archive_path.name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path, "r") as zip:
+            # list contents
+            for member in zip.infolist():
+                filemode = member.external_attr >> 16
+                executable = filemode & stat.S_IXUSR != 0 and member.file_size > 0
+                print(f"{'* ' if executable else '  '}{member.filename}")
+
+    else:
+        error(f"Unsupported archive format: {archive_path.suffix}")
+        return None
+
+
+def _download_and_extract_solver(
+    solver_info: SolverInfo, url: str, expected_checksum: str
+) -> Path | None:
+    """Downloads, verifies, and extracts the solver archive."""
+    binary_path_in_cache = SOLVER_CACHE_DIR / (
+        solver_info.binary_name_in_cache or solver_info.binary_name_in_archive
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive_path = Path(tmpdir) / Path(url).name
+        info(f"Downloading {solver_info.name} from {url}...")
+        try:
+            response = requests.get(url, stream=True, timeout=300)  # 5 min timeout
+            response.raise_for_status()
+            with open(archive_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            info(f"Downloaded to {archive_path}")
+
+            # Verify checksum
+            if not _verify_checksum(archive_path, expected_checksum):
+                # Keep the downloaded file for inspection if checksum fails? For now, let's delete.
+                error(
+                    f"Checksum verification failed for {archive_path}. Aborting installation."
+                )
+                return None
+
+            # Extract the archive
+            info(f"Extracting {archive_path}...")
+            if url.endswith(".tar.gz"):
+                with tarfile.open(archive_path, "r:gz") as tar:
+                    # Find the binary member
+                    # Search within common parent directories too (e.g., yices-2.6.5-..../bin/yices-smt2)
+                    member_to_extract = None
+                    for member in tar.getmembers():
+                        if member.name.endswith(
+                            f"/{solver_info.binary_name_in_archive}"
+                        ):
+                            member_to_extract = member
+                            break
+
+                    if not member_to_extract:
+                        error(
+                            f"Could not find binary '{solver_info.binary_name_in_archive}' in {archive_path}"
+                        )
+                        return None
+
+                    # Extract just the binary to the temp dir first
+                    member_to_extract.name = Path(
+                        member_to_extract.name
+                    ).name  # Extract without full path
+                    tar.extract(member_to_extract, path=tmpdir)
+                    extracted_binary_path = Path(tmpdir) / member_to_extract.name
+
+                    # Move to cache and make executable
+                    shutil.move(str(extracted_binary_path), str(binary_path_in_cache))
+                    binary_path_in_cache.chmod(
+                        binary_path_in_cache.stat().st_mode
+                        | stat.S_IXUSR
+                        | stat.S_IXGRP
+                        | stat.S_IXOTH
+                    )
+                    info(
+                        f"Solver '{solver_info.name}' installed to {binary_path_in_cache}"
+                    )
+                    return binary_path_in_cache
+            # Add handling for other archive types (e.g., .zip) if needed
+            else:
+                error(f"Unsupported archive format for URL: {url}")
+                return None
+
+        except requests.exceptions.RequestException as e:
+            error(f"Failed to download {solver_info.name}: {e}")
+            return None
+        except tarfile.TarError as e:
+            error(f"Failed to extract {archive_path}: {e}")
+            return None
+        except Exception as e:
+            error(f"An unexpected error occurred during solver installation: {e}")
+            return None
+
+    return None  # Should not be reached if successful
+
+
+def find_solver_binary(solver_name: str) -> Path | None:
+    """
+    Finds the solver binary path.
+    Checks cache first, then PATH, then venv (for z3).
+    """
+    if solver_name not in SUPPORTED_SOLVERS:
+        warn(f"Solver '{solver_name}' is not explicitly supported by halmos.")
+        # Still try PATH as a fallback
+        return shutil.which(solver_name)
+
+    solver_info = SUPPORTED_SOLVERS[solver_name]
+    binary_name = solver_info.binary_name_in_cache or solver_info.binary_name_in_archive
+    cached_binary_path = SOLVER_CACHE_DIR / binary_name
+
+    # 1. Check cache
+    if cached_binary_path.exists() and os.access(cached_binary_path, os.X_OK):
+        debug(f"Found {solver_name} binary in cache: {cached_binary_path}")
+        return cached_binary_path
+
+    # 2. Check PATH (using the cached name first, then the base name)
+    path_binary = shutil.which(binary_name) or shutil.which(
+        solver_info.binary_name_in_archive
+    )
+    if path_binary:
+        debug(f"Found {solver_name} binary in PATH: {path_binary}")
+        return Path(path_binary)
+
+    # 3. Special check for z3 in venv (using logic from config.py)
+    if solver_name == "z3":
+        venv_z3 = find_z3_path_in_venv()  # We'll need to define or import this helper
+        if venv_z3:
+            debug(f"Found z3 binary in venv: {venv_z3}")
+            return venv_z3
+
+    debug(f"Solver binary '{binary_name}' not found in cache or PATH.")
+    return None
+
+
+def ensure_solver_available(solver_name: str) -> Path | None:
+    """
+    Ensures the specified solver is available, downloading it if necessary.
+    Returns the path to the executable binary or None if unavailable/installation fails.
+    """
+    binary_path = find_solver_binary(solver_name)
+    if binary_path:
+        return binary_path
+
+    # If not found, attempt download for supported solvers with URLs
+    if solver_name not in SUPPORTED_SOLVERS:
+        warn(f"Cannot automatically install unsupported solver: {solver_name}")
+        return None
+
+    solver_info = SUPPORTED_SOLVERS[solver_name]
+    system, machine = get_platform_arch()
+    platform_key = (system, machine)
+
+    if not solver_info.download_urls:
+        warn(
+            f"No download URLs configured for solver '{solver_name}'. Please install it manually and ensure it's in PATH."
+        )
+        return None
+
+    if platform_key not in solver_info.download_urls:
+        error(
+            f"No download URL configured for solver '{solver_name}' on platform {system}/{machine}."
+        )
+        return None
+
+    url = solver_info.download_urls[platform_key]
+    expected_checksum = solver_info.checksums.get(url)
+
+    if not expected_checksum or expected_checksum.startswith("EXPECTED_CHECKSUM"):
+        # For now, proceed without checksum if not defined or placeholder, but warn
+        warn(
+            f"Checksum not defined for {solver_name} URL: {url}. Cannot verify integrity."
+        )
+        # In a stricter mode, we might return None here
+        expected_checksum = None  # Or set to None to skip verification
+
+    # Attempt download and installation
+    installed_path = _download_and_extract_solver(solver_info, url, expected_checksum)
+    return installed_path
+
+
+def get_solver_command(solver_name: str) -> list[str] | None:
+    """
+    Gets the full command list (binary path + arguments) for the specified solver.
+    Ensures the solver is available first.
+    """
+    solver_binary_path = ensure_solver_available(solver_name)
+    if not solver_binary_path:
+        error(f"Solver '{solver_name}' could not be found or installed.")
+        return None
+
+    if solver_name not in SUPPORTED_SOLVERS:
+        # For unsupported solvers found in PATH, return just the binary path
+        return [str(solver_binary_path)]
+
+    solver_info = SUPPORTED_SOLVERS[solver_name]
+    command = [str(solver_binary_path)] + solver_info.arguments
+    debug(f"Solver command for '{solver_name}': {' '.join(command)}")
+    return command
+
+
+# Helper function to find z3 in venv (similar to the one in config.py)
+# Consider moving the original `find_venv_root` and `find_z3_path` to a common utils module
+# For now, let's duplicate/adapt it here.
+def find_venv_root() -> Path | None:
+    if "VIRTUAL_ENV" in os.environ:
+        return Path(os.environ["VIRTUAL_ENV"])
+    # Simplified check - assumes if running within Python env, sys.prefix is relevant
+    if (
+        hasattr(sys, "prefix")
+        and hasattr(sys, "base_prefix")
+        and sys.prefix != sys.base_prefix
+    ):
+        return Path(sys.prefix)
+    return None
+
+
+def find_z3_path_in_venv() -> Path | None:
+    venv_path = find_venv_root()
+    if venv_path:
+        z3_bin = "z3.exe" if platform.system() == "Windows" else "z3"
+        # Check common bin locations
+        for bin_dir in ["bin", "Scripts"]:  # Scripts for Windows venv
+            z3_path = venv_path / bin_dir / z3_bin
+            if z3_path.exists() and os.access(z3_path, os.X_OK):
+                return z3_path
+    return None
+
+
+if __name__ == "__main__":
+    import sys
+    import time
+
+    if not len(sys.argv) > 1:
+        print("Usage: python solvers.py <solver_name>")
+        print("Supported:", list(SUPPORTED_SOLVERS.keys()))
+        sys.exit(1)
+
+    solver_to_test = sys.argv[1]
+    solver_info: SolverInfo = SUPPORTED_SOLVERS[solver_to_test]
+
+    with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+        for download_info in solver_info.downloads.values():
+            print(f"Downloading {download_info.base_url}/{download_info.filename}")
+            archive_path = _download(download_info, Path(tmpdir))
+
+            print(f"Downloaded to {archive_path}")
+            _verify_checksum(archive_path, download_info.checksum)
+
+            print("Listing archive contents:")
+            _list_archive(archive_path)
+
+            print()
+
+            # avoid rate limiting
+            time.sleep(1)
+
+    # confirm deletion
+    if input(f"Delete the temp dir {tmpdir}? (y/N) ") == "y":
+        shutil.rmtree(tmpdir)

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -1278,12 +1278,51 @@ class NamedTimer:
         )
 
 
+def format_size(num_bytes: int) -> str:
+    """
+    Returns a human-readable string for a number of bytes
+    Automatically chooses a relevant size unit (G, M, K, B)
+
+    e.g.:
+        1234567890 -> 1.15G
+        123456789 -> 117.7M
+        123456 -> 120.5K
+        123 -> 123B
+    """
+    if num_bytes >= 1024 * 1024 * 1024:
+        return f"{num_bytes / (1024 * 1024 * 1024):.2f}GB"
+    elif num_bytes >= 1024 * 1024:
+        return f"{num_bytes / (1024 * 1024):.1f}MB"
+    elif num_bytes >= 1024:
+        return f"{num_bytes / 1024:.1f}KB"
+    else:
+        return f"{num_bytes}B"
+
+
 def format_time(seconds: float) -> str:
     """
-    Return a pretty string for an elapsed time in seconds.
-    Automatically choose a relevant time unit among s, ms, µs, ns.
+    Returns a pretty string for an elapsed time in seconds.
+    Automatically chooses a relevant time unit (h, m, s, ms, µs, ns)
+
+    e.g.:
+        3602.13 -> 1h00m02s
+        62.003 -> 1m02s
+        1.000000001 -> 1.000s
+        0.123456789 -> 123.457ms
+        0.000000001 -> 1.000ns
     """
-    if seconds >= 1:
+    if seconds >= 3600:
+        # 1 hour or more
+        hours = int(seconds / 3600)
+        minutes = int((seconds - (3600 * hours)) / 60)
+        seconds_rounded = int(seconds - (3600 * hours) - (60 * minutes))
+        return f"{hours}h{minutes:02}m{seconds_rounded:02}s"
+    elif seconds >= 60:
+        # 1 minute or more
+        minutes = int(seconds / 60)
+        seconds_rounded = int(seconds - (60 * minutes))
+        return f"{minutes}m{seconds_rounded:02}s"
+    elif seconds >= 1:
         # 1 second or more
         return f"{seconds:.3f}s"
     elif seconds >= 1e-3:

--- a/tests/regression/test/Arith.t.sol
+++ b/tests/regression/test/Arith.t.sol
@@ -41,6 +41,7 @@ contract ArithTest {
         }
     }
 
+    /// @custom:halmos --solver yices
     function check_Div_fail(uint x, uint y) public pure {
         require(x > y);
 
@@ -51,6 +52,7 @@ contract ArithTest {
         assert(q != 0); // counterexample: y == 0
     }
 
+    /// @custom:halmos --solver yices
     function check_Div_pass(uint x, uint y) public pure {
         require(x > y);
         require(y > 0);

--- a/tests/regression/test/Arith.t.sol
+++ b/tests/regression/test/Arith.t.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 contract ArithTest {
-
     function unchecked_div(uint x, uint y) public pure returns (uint ret) {
         assembly {
             ret := div(x, y)
@@ -41,7 +40,6 @@ contract ArithTest {
         }
     }
 
-    /// @custom:halmos --solver yices
     function check_Div_fail(uint x, uint y) public pure {
         require(x > y);
 
@@ -52,7 +50,10 @@ contract ArithTest {
         assert(q != 0); // counterexample: y == 0
     }
 
-    /// @custom:halmos --solver yices
+    // this would run better with `@custom:halmos --solver yices`
+    // but the static binaries for yices on macOS actually link against libcudd
+    // which is not available on GitHub Actions runners
+    // https://github.com/a16z/halmos/issues/492
     function check_Div_pass(uint x, uint y) public pure {
         require(x > y);
         require(y > 0);

--- a/tests/regression/test/Arith.t.sol
+++ b/tests/regression/test/Arith.t.sol
@@ -40,6 +40,7 @@ contract ArithTest {
         }
     }
 
+    /// @custom:halmos --solver yices
     function check_Div_fail(uint x, uint y) public pure {
         require(x > y);
 
@@ -50,10 +51,7 @@ contract ArithTest {
         assert(q != 0); // counterexample: y == 0
     }
 
-    // this would run better with `@custom:halmos --solver yices`
-    // but the static binaries for yices on macOS actually link against libcudd
-    // which is not available on GitHub Actions runners
-    // https://github.com/a16z/halmos/issues/492
+    /// @custom:halmos --solver yices
     function check_Div_pass(uint x, uint y) public pure {
         require(x > y);
         require(y > 0);


### PR DESCRIPTION
implement the suggestion in https://github.com/a16z/halmos/issues/469, with just yices for now

- `--solver` defaults to z3, and `--solver-command` defaults to empty
- `--solver-command` is still available, it can be overriden anywhere and takes precedence over `--solver`
- when `--solver-command` is empty, it is resolved dynamically based on the selected solver name. We look for it in the binary cache (`~/.halmos/solvers`), and if it's not there we download it from a predefined releases URL, check its integrity against a known checksum and extract the binary in the halmos cache
- `--solver` can be overriden at the function level

Example flow:

```
# on first run:
$ halmos --debug --solver yices 
...
DEBUG    Solver binary 'yices' not found in cache or PATH.                                                                                                                                                                                                                                                              
INFO     Downloading from https://github.com/SRI-CSL/yices2/releases/download/Yices-2.6.5/yices-2.6.5-x86_64-apple-darwin21.6.0-static-gmp.tar.gz...                                                                                                                                                                    
INFO     Verifying sha256 hash for /var/folders/p9/s6g8495n6dqdjq3nn8hkdn840000gn/T/tmpjvb6319n/yices-2.6.5-x86_64-apple-darwin21.6.0-static-gmp.tar.gz...                                                                                                                                                              
INFO     Extracting yices-2.6.5/bin/yices-smt2 from /var/folders/p9/s6g8495n6dqdjq3nn8hkdn840000gn/T/tmpjvb6319n/yices-2.6.5-x86_64-apple-darwin21.6.0-static-gmp.tar.gz...                                                                                                                                             
INFO     Wrote /Users/karma/.halmos/solvers/yices (2.5MB)                                                                                                                                                                                                                                                               
DEBUG    Solver command for 'yices': /Users/karma/.halmos/solvers/yices --smt2-model-format

# on subsequent runs
$ halmos --debug --solver yices 
...
DEBUG    Found yices binary in cache: /Users/karma/.halmos/solvers/yices                                                                                                                                                                                                                                                
DEBUG    Solver command for 'yices': /Users/karma/.halmos/solvers/yices --smt2-model-format

# we look for z3 in the venv root, same as before
$ halmos --debug --solver z3
...
DEBUG    Found z3 binary in venv: /Users/karma/projects/halmos/.venv/bin/z3                                                                                                                                                                                                                                             
DEBUG    Solver command for 'z3': /Users/karma/projects/halmos/.venv/bin/z3  
```

Note that jsi doesn't follow the same one binary model, so for now it still has to be installed separately and invoked with `--solver-command`.

TODO:
- [ ] bitwuzla
- [ ] cvc5
- [x] verify windows support