### PR TITLE
fix: self-transfer value

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -2502,7 +2502,6 @@ class SEVM:
             return
 
         caller_balance: BitVecRef = ex.balance_of(caller)
-        to_balance: BitVecRef = ex.balance_of(to)
 
         # assume balance is enough; otherwise ignore this path
         # note: evm requires enough balance even for self-transfer
@@ -2517,7 +2516,8 @@ class SEVM:
             value = If(condition, value, Z3_ZERO)
 
         ex.balance_update(caller, BV(caller_balance).sub(value))
-        ex.balance_update(to, BV(to_balance).add(value))
+        # NOTE: ex.balance_of(to) must be called **after** updating the caller's balance above, to correctly handle the self-transfer case
+        ex.balance_update(to, BV(ex.balance_of(to)).add(value))
 
     def call(
         self,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -3073,7 +3073,7 @@
         ],
         "test/Send.t.sol:SendTest": [
             {
-                "name": "check_create(address,uint256,address,bytes32,uint256)",
+                "name": "check_create(uint256,bytes32,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -3082,7 +3082,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_send(address,uint256,address,uint256)",
+                "name": "check_send(uint256,uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,
@@ -3091,7 +3091,7 @@
                 "num_bounded_loops": null
             },
             {
-                "name": "check_transfer(address,uint256,address)",
+                "name": "check_transfer(uint256)",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,


### PR DESCRIPTION
the balance update logic was incorrect in the self-transfer case. this bug was introduced during the large refactoring in #470, but it wasn't caught by the existing tests. specifically, SendTest was supposed to catch this bug, but the test had been written under the assumption that initial setup balances were symbolic, which became invalid after we modified the initial setup balance to be zero.

this pr fixed both the balance update logic and the test.