### PR TITLE
test: add pectra external test

### DIFF
--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -108,7 +108,8 @@ jobs:
             apt-get update && \
             apt-get install -y golang-go && \
             go version && \
-            go install github.com/fjl/geas/cmd/geas@latest"
+            env 'GOBIN=/halmos/bin' go install github.com/fjl/geas/cmd/geas@latest && \
+            geas -h"
           docker commit tmp-halmos-image halmos-image
 
       - name: Checkout external repo

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -94,7 +94,7 @@ jobs:
           # commit the result back to halmos-image
           docker commit halmos-image-foundryup halmos-image
 
-      # for pcaversaccio/snekmate
+      # for snekmate
       - name: Install Vyper
         if: ${{ matrix.project.dir == 'snekmate' }}
         run: |
@@ -105,6 +105,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
 
+      # for sys-asm-halmos
       - name: Install Geas
         run: go install github.com/fjl/geas/cmd/geas@latest
 

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -102,12 +102,14 @@ jobs:
           docker commit halmos-image-vyper halmos-image
 
       # for sys-asm-halmos
-      - name: Setup Go
-        uses: actions/setup-go@v4
-
-      # for sys-asm-halmos
       - name: Install Geas
-        run: go install github.com/fjl/geas/cmd/geas@latest
+        run: |
+          docker run --name tmp-halmos-image halmos-image bash -c "\
+            apt-get update && \
+            apt-get install -y golang-go && \
+            go version && \
+            go install github.com/fjl/geas/cmd/geas@latest"
+          docker commit tmp-halmos-image halmos-image
 
       - name: Checkout external repo
         uses: actions/checkout@v4

--- a/.github/workflows/test-external.yml
+++ b/.github/workflows/test-external.yml
@@ -70,6 +70,11 @@ jobs:
             cmd: "--config test/halmos.toml --contract MathTestHalmos --solver-command 'jsi --model --sequence yices,bitwuzla-abstraction' --solver-threads 1"
             branch: ""
             profile: "halmos-venom"
+          - repo: "daejunpark/sys-asm-halmos"
+            dir: "sys-asm-halmos"
+            cmd: "--solver-threads 3 --loop 2"
+            branch: ""
+            profile: ""
 
     steps:
       - name: Checkout halmos
@@ -89,11 +94,19 @@ jobs:
           # commit the result back to halmos-image
           docker commit halmos-image-foundryup halmos-image
 
+      # for pcaversaccio/snekmate
       - name: Install Vyper
         if: ${{ matrix.project.dir == 'snekmate' }}
         run: |
           docker run --name halmos-image-vyper halmos-image uv pip install git+https://github.com/vyperlang/vyper@master
           docker commit halmos-image-vyper halmos-image
+
+      # for sys-asm-halmos
+      - name: Setup Go
+        uses: actions/setup-go@v4
+
+      - name: Install Geas
+        run: go install github.com/fjl/geas/cmd/geas@latest
 
       - name: Checkout external repo
         uses: actions/checkout@v4


### PR DESCRIPTION
the [pectra formal verification ci](https://github.com/daejunpark/sys-asm-halmos/actions) broke after #470 and #484. to prevent further regressions, the pectra test has been added to the external test ci. to reduce ci overhead, the loop bound is set to 2 in our ci (vs 16 in the original pectra fv ci).