### PR TITLE
improve progress display

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -594,8 +594,10 @@ def _compute_frontier(ctx: ContractContext, depth: int) -> Iterator[Exec]:
     panic_error_codes = ctx.args.panic_error_codes
     flamegraph_enabled = ctx.args.flamegraph
 
+    contract_name = ctx.name
     for idx, pre_ex in enumerate(curr_exs):
         progress_status.update(
+            f"{contract_name}: "
             f"depth: {cyan(depth)} | "
             f"starting states: {cyan(len(curr_exs))} | "
             f"unique states: {cyan(len(visited))} | "
@@ -969,7 +971,9 @@ def run_test(ctx: FunctionContext) -> TestResult:
             if done == total:
                 break
             elapsed = timedelta(seconds=int(timer.elapsed()))
-            progress_status.update(f"[{elapsed}] solving queries: {done} / {total}")
+            progress_status.update(
+                f"{funsig}: [{elapsed}] solving queries: {done} / {total}"
+            )
             time.sleep(0.1)
 
     ctx.thread_pool.shutdown(wait=True)

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -3239,6 +3239,13 @@ class SEVM:
         profile_instructions = self.options.profile_instructions
         profiler = Profiler()
         start_time = timer()
+        fun_name = self.fun_info.name
+
+        # TODO: break the backward dependency from traces, and use the existing trace lender methods
+        call_seq_str = "\n".join(
+            f"{hexify(call.message.target)}::{hexify(call.message.data[:4].unwrap())}"
+            for call in ex0.call_sequence
+        )
 
         step_id = 0
         step_interval_mask = PULSE_INTERVAL - 1
@@ -3264,9 +3271,11 @@ class SEVM:
                     elapsed_fmt = timedelta(seconds=int(elapsed))
 
                     progress_status.update(
+                        f"{fun_name}: "
                         f"[{elapsed_fmt}] {speed:.0f} ops/s"
                         f" | completed paths: {stack.completed_paths}"
                         f" | outstanding paths: {len(stack)}"
+                        f"\n{call_seq_str}"
                     )
 
                 if not ex.path.is_activated():


### PR DESCRIPTION
improved the progress display for invariant testing runs by showing the current context and call sequence.

for example:
```
Running 1 tests for test/08-omni-protocol/OmniAdvancedHalmos.t.sol:OmniAdvancedHalmos
⠸ deposit: [0:00:04] 16743 ops/s | completed paths: 62 | outstanding paths: 3
0x7fa9385be102ac3eac297483dd6233d62b3e1496::clearMarkets
0x7fa9385be102ac3eac297483dd6233d62b3e1496::liquidate
```