### PR TITLE
Fix/prompt status clash + cvc5 and bitwuzla configs

### DIFF
--- a/src/halmos/build.py
+++ b/src/halmos/build.py
@@ -6,6 +6,7 @@ import traceback
 from halmos.config import Config as HalmosConfig
 from halmos.logs import PARSING_ERROR, debug, warn_code
 from halmos.mapper import Mapper
+from halmos.ui import ui
 
 
 def get_contract_type(
@@ -30,6 +31,7 @@ def parse_build_out(args: HalmosConfig) -> dict:
             f"The build output directory `{out_path}` does not exist"
         )
 
+    ui.update_status(f"Parsing {out_path}")
     for sol_dirname in os.listdir(out_path):  # for each source filename
         if not sol_dirname.endswith(".sol"):
             continue

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -11,13 +11,14 @@ from typing import Any
 
 import toml
 
-from .logs import warn
+from halmos.logs import warn
+from halmos.solvers import SOLVERS
 
 # common strings
 internal = "internal"
 
 # groups
-debugging, solver, build, experimental, deprecated = (
+debugging, solver_group, build, experimental, deprecated = (
     "Debugging options",
     "Solver options",
     "Build options",
@@ -38,7 +39,7 @@ def arg(
     global_default: Any,
     metavar: str | None = None,
     group: str | None = None,
-    choices: str | None = None,
+    choices: list[str] | None = None,
     short: str | None = None,
     countable: bool = False,
     global_default_str: str | None = None,
@@ -459,55 +460,57 @@ class Config:
         help="specify the SMT solver to use (e.g., 'yices'). If not specified, defaults to 'z3'. If --solver-command is used, this is ignored.",
         global_default="z3",
         metavar="SOLVER_NAME",
-        choices=["yices", "z3"],
-        group=solver,
+        choices=list(SOLVERS.keys()),
+        group=solver_group,
     )
 
     smt_exp_by_const: int = arg(
         help="interpret constant power up to N",
         global_default=2,
         metavar="N",
-        group=solver,
+        group=solver_group,
     )
 
     solver_timeout_branching: int = arg(
         help="set timeout (in milliseconds) for solving branching conditions; 0 means no timeout",
         global_default=1,
         metavar="TIMEOUT",
-        group=solver,
+        group=solver_group,
     )
 
     solver_timeout_assertion: int = arg(
         help="set timeout (in milliseconds) for solving assertion violation conditions; 0 means no timeout",
         global_default=60_000,
         metavar="TIMEOUT",
-        group=solver,
+        group=solver_group,
     )
 
     solver_max_memory: int = arg(
         help="set memory limit (in megabytes) for the solver; 0 means no limit",
         global_default=0,
         metavar="SIZE",
-        group=solver,
+        group=solver_group,
     )
 
     solver_command: str = arg(
         help="use the given exact command when invoking the solver (overrides automatic solver detection/download triggered by --solver)",
         global_default=None,
         metavar="COMMAND",
-        group=solver,
+        group=solver_group,
     )
 
     solver_threads: int = arg(
         help="set the number of threads for parallel solvers",
         metavar="N",
-        group=solver,
+        group=solver_group,
         global_default=(lambda: os.cpu_count() or 1),
         global_default_str="number of CPUs",
     )
 
     cache_solver: bool = arg(
-        help="cache unsat queries using unsat cores", global_default=False, group=solver
+        help="cache unsat queries using unsat cores",
+        global_default=False,
+        group=solver_group,
     )
 
     ### Experimental options

--- a/src/halmos/logs.py
+++ b/src/halmos/logs.py
@@ -17,7 +17,7 @@ progress_status: Status = Status("")
 
 logging.basicConfig(
     format="%(message)s",
-    handlers=[RichHandler(level=logging.NOTSET, show_time=False, show_path=False)],
+    handlers=[RichHandler(level=logging.INFO, show_time=False, show_path=False)],
 )
 
 logger = logging.getLogger("halmos")

--- a/src/halmos/logs.py
+++ b/src/halmos/logs.py
@@ -2,14 +2,6 @@ import logging
 from dataclasses import dataclass
 
 from rich.logging import RichHandler
-from rich.status import Status
-
-#
-# Progress status
-#
-
-progress_status: Status = Status("")
-
 
 #
 # Basic logging

--- a/src/halmos/logs.py
+++ b/src/halmos/logs.py
@@ -9,7 +9,7 @@ from rich.logging import RichHandler
 
 logging.basicConfig(
     format="%(message)s",
-    handlers=[RichHandler(level=logging.INFO, show_time=False, show_path=False)],
+    handlers=[RichHandler(level=logging.NOTSET, show_time=False, show_path=False)],
 )
 
 logger = logging.getLogger("halmos")

--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -86,11 +86,11 @@ from .logs import (
     LIBRARY_PLACEHOLDER,
     debug,
     debug_once,
-    progress_status,
     warn,
     warn_code,
 )
 from .mapper import BuildOut
+from .ui import ui
 from .utils import (
     Address,
     BitVecSort160,
@@ -3285,7 +3285,7 @@ class SEVM:
                     # hh:mm:ss
                     elapsed_fmt = timedelta(seconds=int(elapsed))
 
-                    progress_status.update(
+                    ui.update_status(
                         f"{fun_name}: "
                         f"[{elapsed_fmt}] {speed:.0f} ops/s"
                         f" | completed paths: {stack.completed_paths}"

--- a/src/halmos/solvers.py
+++ b/src/halmos/solvers.py
@@ -11,15 +11,15 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 import requests
-from rich.console import Console
 
-from halmos.logs import debug, error, info
+from halmos.logs import debug, error
+from halmos.ui import ui
 from halmos.utils import format_size
 
 # not defaulting to latest because of https://github.com/a16z/halmos/issues/492
 DEFAULT_YICES_VERSION = "2.6.4"
 
-DEFAULT_CVC5_VERSION = "1.1.2"
+DEFAULT_CVC5_VERSION = "1.2.1"
 
 # Define the cache directory for solvers
 SOLVER_CACHE_DIR = Path.home() / ".halmos" / "solvers"
@@ -27,8 +27,6 @@ SOLVER_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 # environment variable to bypass the interactive download confirmation prompt
 ALLOW_DOWNLOAD_VAR = "HALMOS_ALLOW_DOWNLOAD"
-
-console = Console()
 
 
 def yices_base_url(version: str) -> str:
@@ -161,33 +159,33 @@ SOLVERS: dict[str, SolverInfo] = {
         downloads={},
         arguments=["--produce-models", "--abstraction"],
     ),
-    "cvc5-1.1.2": SolverInfo(
-        name="cvc5-1.1.2",
+    "cvc5-1.2.1": SolverInfo(
+        name="cvc5-1.2.1",
         binary_name="cvc5",
         downloads={
             macos_intel: DownloadInfo(
-                base_url=cvc5_base_url("1.1.2"),
+                base_url=cvc5_base_url("1.2.1"),
                 filename="cvc5-macOS-x86_64-static.zip",
-                checksum="XYZ",
-                binary_name_in_archive="cvc5",
+                checksum="bdde9557bbb9b812af270c3f418836c285957b3ed81385b87428d2d595ffbf47",
+                binary_name_in_archive="cvc5-macOS-x86_64-static/bin/cvc5",
             ),
             macos_arm64: DownloadInfo(
-                base_url=cvc5_base_url("1.1.2"),
+                base_url=cvc5_base_url("1.2.1"),
                 filename="cvc5-macOS-arm64-static.zip",
-                checksum="XYZ",
-                binary_name_in_archive="cvc5",
+                checksum="18e0bd283d44f720f72bf80175169ef63e985628b7ba1502aaf812f57f981461",
+                binary_name_in_archive="cvc5-macOS-arm64-static/bin/cvc5",
             ),
             linux_intel: DownloadInfo(
-                base_url=cvc5_base_url("1.1.2"),
+                base_url=cvc5_base_url("1.2.1"),
                 filename="cvc5-Linux-x86_64-static.zip",
-                checksum="XYZ",
-                binary_name_in_archive="cvc5",
+                checksum="6d44abc233980a14d72cc5809287d27c3335b1d6ee863381d0b5ffcbd0d8de56",
+                binary_name_in_archive="cvc5-Linux-x86_64-static/bin/cvc5",
             ),
             windows_intel: DownloadInfo(
-                base_url=cvc5_base_url("1.1.2"),
+                base_url=cvc5_base_url("1.2.1"),
                 filename="cvc5-Win64-x86_64-static.zip",
-                checksum="XYZ",
-                binary_name_in_archive="cvc5.exe",
+                checksum="a5cfbb258fa5421f9e8ba11aad968b1b542e5913a8907b0bddcdb2a91313fca8",
+                binary_name_in_archive="cvc5-Win64-x86_64-static/bin/cvc5.exe",
             ),
         },
         arguments=["--produce-models"],
@@ -313,13 +311,15 @@ def download_allowed(solver: SolverInfo, download_info: DownloadInfo) -> bool:
     Checks if the download is allowed.
     """
 
-    if not console.is_interactive:
-        return os.environ.get(ALLOW_DOWNLOAD_VAR, "false").lower() in ["true", "1"]
+    bypass = os.environ.get(ALLOW_DOWNLOAD_VAR, "false").lower() in ["true", "1"]
+    if bypass:
+        return True
 
-    prompt = (
-        f"Do you want to download {solver.name} from {download_info.base_url}? (y/N) "
-    )
-    return input(prompt).lower() == "y"
+    if not ui.is_interactive:
+        return bypass
+
+    prompt = f"Do you want to download {solver.name} from {download_info.base_url}?"
+    return ui.prompt(prompt)
 
 
 def install_solver(solver: SolverInfo) -> Path:
@@ -339,22 +339,24 @@ def install_solver(solver: SolverInfo) -> Path:
             f"Download not allowed (configure {ALLOW_DOWNLOAD_VAR}=1 to bypass)"
         )
 
+    ui.update_status(f"Installing {solver.name}")
+
     with tempfile.TemporaryDirectory() as tmpdir:
         # Download the archive
         url = download_info.base_url + "/" + download_info.filename
-        info(f"Downloading from {url}...")
+        ui.print(f"Downloading {url}")
         archive_path = download(download_info, Path(tmpdir))
 
         if not archive_path:
             raise RuntimeError(f"Failed to download {solver.name} from {url}")
 
         # Verify checksum
-        info(f"Verifying sha256 hash for {archive_path}... ")
+        ui.print(f"Verifying sha256 hash for [bold]{download_info.filename}[/bold]")
         verify_checksum(archive_path, download_info.checksum)
 
         # Extract the binary from the archive
         binary_filename = download_info.binary_name_in_archive
-        info(f"Extracting {binary_filename} from {archive_path}...")
+        ui.print(f"Extracting [bold]{binary_filename}[/bold]")
         content = extract_file(archive_path, binary_filename)
         if not content:
             raise RuntimeError(
@@ -366,8 +368,12 @@ def install_solver(solver: SolverInfo) -> Path:
         if install_path.exists():
             raise RuntimeError(f"File already exists: {install_path}")
 
+        ui.print(
+            f"Solver saved to [bold]{install_path}[/bold] ([cyan]{format_size(len(content))}[/cyan])",
+            highlight=False,
+            markup=True,
+        )
         install_path.write_bytes(content)
-        info(f"Wrote {install_path} ({format_size(len(content))})")
 
         # Make the binary executable
         install_path.chmod(install_path.stat().st_mode | stat.S_IXUSR)

--- a/src/halmos/ui.py
+++ b/src/halmos/ui.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass, field
+
+from rich import get_console
+from rich.console import Console
+from rich.prompt import Confirm
+from rich.status import Status
+
+
+class suspend_status:
+    """Context manager to temporarily suspend a Status."""
+
+    def __init__(self, status: Status):
+        self.status = status
+
+    def __enter__(self):
+        self.status.stop()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.status.start()
+
+
+@dataclass(frozen=True, eq=False, order=False, slots=True)
+class UI:
+    status: Status
+    console: Console = field(default_factory=get_console)
+
+    @property
+    def is_interactive(self) -> bool:
+        return self.console.is_interactive
+
+    def clear_live(self):
+        self.console.clear_live()
+
+    def start_status(self):
+        # clear any remaining live display before starting a new instance
+        self.clear_live()
+        self.status.start()
+
+    def update_status(self, status: str):
+        self.status.update(status)
+
+    def stop_status(self):
+        self.status.stop()
+
+    def prompt(self, prompt: str) -> bool:
+        # non-interactive sessions (e.g. redirected output) will block on input
+        if not self.is_interactive:
+            return False
+
+        with suspend_status(self.status):
+            return Confirm.ask(prompt)
+
+    def print(self, *args, **kwargs):
+        self.console.print(*args, **kwargs)
+
+
+ui: UI = UI(Status(""))
+
+
+if __name__ == "__main__":
+    import time
+
+    print(f"{ui.is_interactive=}")
+
+    # things basically break down if start a rogue status (not managed by the UI class)
+    # time.sleep(1)
+    # print("starting a rogue status")
+    # rogue_status = Status("Rogue status")
+    # rogue_status.start()
+
+    # time.sleep(1)
+    # print("clearing live")
+    # ui.clear_live()
+
+    time.sleep(1)
+    print("starting 'official' status")
+    ui.start_status()
+
+    time.sleep(1)
+    print("updating status")
+    ui.update_status("Status update demo")
+
+    # using the managed prompt should suspend the status
+    # (otherwise the prompt will get clobbered by the next status update)
+    time.sleep(1)
+    answer = ui.prompt("Prompt demo")
+    print(f"{answer=}")
+
+    # status updates should resume after the prompt returns
+    time.sleep(1)
+    print("stopping status")
+    ui.stop_status()
+
+    time.sleep(1)


### PR DESCRIPTION
The problem is that if we display an input/prompt while there is a live status, the status updates will clobber the prompt and we'll be stuck. 

My solution is to introduce a central `ui` class in the `halmos.ui` module that holds the singleton status. As long as status updates and prompts go through this class, things work as expected.