### PR TITLE
fix: resolve solver before invoking setup

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1329,6 +1329,11 @@ def run_contract(ctx: ContractContext) -> list[TestResult]:
 
     try:
         setup_config = with_devdoc(args, setup_info.sig, ctx.contract_json)
+        setup_config = with_resolved_solver(setup_config)
+
+        if setup_config.debug_config:
+            debug(f"{setup_config.formatted_layers()}")
+
         setup_solver = mk_solver(setup_config)
         setup_ctx = FunctionContext(
             args=setup_config,


### PR DESCRIPTION
otherwise can fail with:

```
  File "halmos/src/halmos/solve.py", line 429, in solve_low_level
    cmd_with_file = cmd_list + [smt2_filename]
                    ~~~~~~~~~^~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'
```

meaning that cmd_list has not been resolved