### PR TITLE
feat: add createCalldata with address

### DIFF
--- a/examples/simple/test/Reentrancy.t.sol
+++ b/examples/simple/test/Reentrancy.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+import {SymTest} from "halmos-cheatcodes/SymTest.sol";
+
+import {ERC1155, IERC1155} from "openzeppelin/token/ERC1155/ERC1155.sol";
+import {ERC1155Holder} from "openzeppelin/token/ERC1155/utils/ERC1155Holder.sol";
+import {ReentrancyGuard} from "openzeppelin/utils/ReentrancyGuard.sol";
+
+uint256 constant TOKEN_ID = 1;
+
+contract ERC1155Mock is ERC1155 {
+    constructor() ERC1155("URI") {
+        _mint(msg.sender, TOKEN_ID, 1_000_000_000 ether, "");
+    }
+}
+
+contract ReentrancyVault is ReentrancyGuard, ERC1155Holder {
+    mapping(address => uint) balances;
+    IERC1155 token;
+
+    constructor (IERC1155 _token) {
+        token = _token;
+    }
+
+    function deposit(uint value) public payable {
+        token.safeTransferFrom(msg.sender, address(this), TOKEN_ID, value, "");
+        balances[msg.sender] += value;
+    }
+
+    // ReentrancyTest will pass if nonReentrant is applied
+    function withdraw() public /* nonReentrant */ {
+        uint balance = balances[msg.sender];
+        // reentrancy vulnerability
+        token.safeTransferFrom(address(this), msg.sender, TOKEN_ID, balance, "");
+        balances[msg.sender] = 0;
+    }
+}
+
+contract Attacker is SymTest {
+    uint depth; // reentrancy depth
+    address target; // reentrancy target
+
+    function setDepth(uint _depth) public {
+        depth = _depth;
+    }
+
+    function setTarget(address _target) public {
+        target = _target;
+    }
+
+    function onERC1155Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* id */
+        uint256, /* value */
+        bytes calldata /* data */
+    ) external returns (bytes4) {
+        if (depth == 0) return this.onERC1155Received.selector;
+        depth--;
+
+        bytes memory data = svm.createCalldata(target);
+        target.call(data);
+
+        return this.onERC1155Received.selector;
+    }
+}
+
+/// @custom:halmos --early-exit
+contract ReentrancyTest is SymTest, Test, ERC1155Holder {
+    ERC1155Mock token;
+    ReentrancyVault vault;
+    Attacker attacker;
+
+    uint256 constant ATTACKER_INITIAL_BALANCE = 100_000_000 ether;
+
+    function setUp() public {
+        token = new ERC1155Mock();
+
+        // deploy vault with initial deposit
+        vault = new ReentrancyVault(IERC1155(token));
+        token.setApprovalForAll(address(vault), true);
+        vault.deposit(1_000_000 ether);
+
+        // deploy attacker with initial balance
+        attacker = new Attacker();
+        token.safeTransferFrom(address(this), address(attacker), TOKEN_ID, ATTACKER_INITIAL_BALANCE, "");
+
+        // make attacker's initial deposit into vault
+        vm.startPrank(address(attacker));
+        token.setApprovalForAll(address(vault), true);
+        vault.deposit(1_000_000 ether);
+        vm.stopPrank();
+
+        // configure attacker
+        attacker.setDepth(1);
+        attacker.setTarget(address(vault));
+
+        targetContract(address(vault));
+    }
+
+    function check_setup() public {
+        assertEq(token.balanceOf(address(this), TOKEN_ID), 999_000_000 ether - ATTACKER_INITIAL_BALANCE);
+        assertEq(token.balanceOf(address(attacker), TOKEN_ID), 99_000_000 ether);
+        assertEq(token.balanceOf(address(vault), TOKEN_ID), 2_000_000 ether);
+    }
+
+    function invariant_no_stolen_funds() public {
+        assertLe(token.balanceOf(address(attacker), TOKEN_ID), ATTACKER_INITIAL_BALANCE);
+    }
+}

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -295,11 +295,15 @@ def _get_contract_name(ex, arg) -> tuple[str | None, str | None]:
         int_of(extract_bytes(arg, 4, 32), "symbolic address for SVM.createCalldata()"),
         size_bits=160,
     )
-    code = ex.code[addr]
+
+    if not (code := ex.code.get(addr)):
+        raise HalmosException(f"createCalldata: not contract account: {hexify(addr)}")
+
     if not (contract_name := code.contract_name):
         raise HalmosException(
             f"createCalldata: couldn't find the contract name for: {hexify(addr)}"
         )
+
     return contract_name, code.filename
 
 

--- a/src/halmos/cheatcodes.py
+++ b/src/halmos/cheatcodes.py
@@ -297,7 +297,9 @@ def _get_contract_name(ex, arg) -> tuple[str | None, str | None]:
     )
     code = ex.code[addr]
     if not (contract_name := code.contract_name):
-        raise HalmosException(f"createCalldata: couldn't find the contract name for: {hexify(addr)}")
+        raise HalmosException(
+            f"createCalldata: couldn't find the contract name for: {hexify(addr)}"
+        )
     return contract_name, code.filename
 
 
@@ -364,7 +366,9 @@ def encode_tuple_bytes(data: BitVecRef | ByteVec | bytes) -> ByteVec:
     return result
 
 
-def create_calldata_generic(ex, sevm, contract_name, filename=None, include_view=False) -> list[ByteVec]:
+def create_calldata_generic(
+    ex, sevm, contract_name, filename=None, include_view=False
+) -> list[ByteVec]:
     """
     Generate arbitrary symbolic calldata for the given contract.
 

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1632,6 +1632,24 @@
         ],
         "test/HalmosCheatCode.t.sol:HalmosCreateCalldataTest": [
             {
+                "name": "check_createCalldata_Beep_0_excluding_pure()",
+                "exitcode": 4,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createCalldata_Beep_0_including_pure()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
                 "name": "check_createCalldata_Beep_1_excluding_pure()",
                 "exitcode": 4,
                 "num_models": 0,
@@ -1678,6 +1696,42 @@
             },
             {
                 "name": "check_createCalldata_Fallback()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createCalldata_Mock_0_excluding_view_fail()",
+                "exitcode": 1,
+                "num_models": 18,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createCalldata_Mock_0_excluding_view_pass()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createCalldata_Mock_0_including_view_fail()",
+                "exitcode": 1,
+                "num_models": 20,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "check_createCalldata_Mock_0_including_view_pass()",
                 "exitcode": 0,
                 "num_models": 0,
                 "models": null,

--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -1900,6 +1900,15 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_createCalldata_unknown_fail()",
+                "exitcode": 3,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/Invariant.t.sol:InvariantProxyTest": [

--- a/tests/expected/simple.json
+++ b/tests/expected/simple.json
@@ -245,6 +245,26 @@
                 "num_bounded_loops": null
             }
         ],
+        "test/Reentrancy.t.sol:ReentrancyTest": [
+            {
+                "name": "check_setup()",
+                "exitcode": 0,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            },
+            {
+                "name": "invariant_no_stolen_funds()",
+                "exitcode": 1,
+                "num_models": 1,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
+            }
+        ],
         "test/SimpleState.t.sol:SimpleStateTest": [
             {
                 "name": "check_buggy_excluding_view()",

--- a/tests/regression/test/HalmosCheatCode.t.sol
+++ b/tests/regression/test/HalmosCheatCode.t.sol
@@ -285,6 +285,19 @@ contract HalmosCheatCodeTest is SymTest, Test {
 
 /// @custom:halmos --default-bytes-lengths 0,65
 contract HalmosCreateCalldataTest is SymTest, Test {
+    Beep beep = new Beep();
+    Mock mock = new Mock(false); // use Mock(true) for debugging
+
+    function check_createCalldata_Beep_0_excluding_pure() public {
+        bytes memory data = svm.createCalldata(address(beep));
+        _check_createCalldata_Beep(data); // fail because the only function in Beep is pure, which is excluded in createCalldata()
+    }
+
+    function check_createCalldata_Beep_0_including_pure() public {
+        bytes memory data = svm.createCalldata(address(beep), true);
+        _check_createCalldata_Beep(data);
+    }
+
     function check_createCalldata_Beep_1_excluding_pure() public {
         bytes memory data = svm.createCalldata("HalmosCheatCode.t.sol", "Beep");
         _check_createCalldata_Beep(data); // fail because the only function in Beep is pure, which is excluded in createCalldata()
@@ -306,11 +319,28 @@ contract HalmosCreateCalldataTest is SymTest, Test {
     }
 
     function _check_createCalldata_Beep(bytes memory data) public {
-        Beep beep = new Beep();
         (bool success, bytes memory retdata) = address(beep).call(data);
         vm.assume(success);
         uint ret = abi.decode(retdata, (uint256));
         assertEq(ret, 42);
+    }
+
+    function check_createCalldata_Mock_0_excluding_view_pass() public {
+        bytes memory data = svm.createCalldata(address(mock));
+        _check_createCalldata_Mock(data, true);
+    }
+    function check_createCalldata_Mock_0_excluding_view_fail() public {
+        bytes memory data = svm.createCalldata(address(mock));
+        _check_createCalldata_Mock(data, false);
+    }
+
+    function check_createCalldata_Mock_0_including_view_pass() public {
+        bytes memory data = svm.createCalldata(address(mock), true);
+        _check_createCalldata_Mock(data, true);
+    }
+    function check_createCalldata_Mock_0_including_view_fail() public {
+        bytes memory data = svm.createCalldata(address(mock), true);
+        _check_createCalldata_Mock(data, false);
     }
 
     function check_createCalldata_Mock_1_pass() public {
@@ -386,8 +416,7 @@ contract HalmosCreateCalldataTest is SymTest, Test {
     }
 
     function _check_createCalldata_Mock(bytes memory data, bool pass) public {
-        Mock target = new Mock(false); // use Mock(true) for debugging
-        _check_createCalldata_generic(address(target), data, pass);
+        _check_createCalldata_generic(address(mock), data, pass);
     }
 
     function _check_createCalldata_generic(address target, bytes memory data, bool pass) public {

--- a/tests/regression/test/HalmosCheatCode.t.sol
+++ b/tests/regression/test/HalmosCheatCode.t.sol
@@ -288,6 +288,11 @@ contract HalmosCreateCalldataTest is SymTest, Test {
     Beep beep = new Beep();
     Mock mock = new Mock(false); // use Mock(true) for debugging
 
+    function check_createCalldata_unknown_fail() public {
+        // fail because 0xbeef is not a contract account
+        bytes memory data = svm.createCalldata(address(0xbeef));
+    }
+
     function check_createCalldata_Beep_0_excluding_pure() public {
         bytes memory data = svm.createCalldata(address(beep));
         _check_createCalldata_Beep(data); // fail because the only function in Beep is pure, which is excluded in createCalldata()


### PR DESCRIPTION
adds an alternative version of createCalldata that takes a target address instead of a contract name.

for now, it supports only concrete addresses.