### PR TITLE
fix: too many open files

### DIFF
--- a/tests/expected/all.json
+++ b/tests/expected/all.json
@@ -4508,6 +4508,15 @@
                 "num_paths": null,
                 "time": null,
                 "num_bounded_loops": null
+            },
+            {
+                "name": "check_too_many_open_files()",
+                "exitcode": 2,
+                "num_models": 0,
+                "models": null,
+                "num_paths": null,
+                "time": null,
+                "num_bounded_loops": null
             }
         ],
         "test/SortMismatch.t.sol:SortMismatchTest": [

--- a/tests/regression/test/Solver.t.sol
+++ b/tests/regression/test/Solver.t.sol
@@ -10,4 +10,30 @@ contract SolverTest is SymTest, Test {
     function check_dynamic_array_overflow() public {
         numbers = new uint[](5); // shouldn't generate loop bounds warning
     }
+
+    /// @custom:halmos --solver-timeout-assertion 1
+    function check_too_many_open_files() public {
+        // regression test for too many open files error: https://github.com/a16z/halmos/issues/523
+        // this test simulates a situation where many solver processes are killed due to timeout.
+        // if file descriptors are not properly closed, this test will fail with "Too many open files" error.
+        if (svm.createBool("*")) { some_hard_query(); } else { some_hard_query(); }
+        if (svm.createBool("*")) { some_hard_query(); } else { some_hard_query(); }
+        if (svm.createBool("*")) { some_hard_query(); } else { some_hard_query(); }
+        if (svm.createBool("*")) { some_hard_query(); } else { some_hard_query(); }
+        if (svm.createBool("*")) { some_hard_query(); } else { some_hard_query(); }
+        if (svm.createBool("*")) { some_hard_query(); } else { some_hard_query(); }
+    }
+
+    function some_hard_query() internal {
+        uint a = svm.createUint256("a");
+        uint b = svm.createUint256("b");
+        uint c = svm.createUint256("c");
+        uint n = svm.createUint256("n");
+
+        vm.assume(n > 2);
+        // we use a simple arithmetic constraint that is hard enough to solve within the 1ms timeout,
+        // which is sufficient for testing that solver processes are properly killed and cleaned up.
+        // note: we avoid exponentiation (a**n + b**n != c**n) as it creates too many execution paths at bytecode level.
+        assertNotEq(a*n + b*n, c*n);
+    }
 }


### PR DESCRIPTION
fixes #523 

the error "OSError: [Errno 24] Too many open files" occurred when many solver processes were killed due to timeout, where the file descriptors of python subprocess objects weren't properly closed, leading to resource leaks.

note that when a process is killed via psutil, the file descriptors may remain open on the Python side, e.g.,:
```python
p = Popen(['ls'], stdout=PIPE, stderr=PIPE)                                                          
psutil.Process(p.pid).kill()
print(p.stdout.closed)  # False - the pipe is still open!
```