### PR TITLE
implement explicit config source precedence

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -211,6 +211,13 @@ def with_resolved_solver(args: HalmosConfig) -> HalmosConfig:
 
     # `--solver-command` overrides `--solver` if it is at least as high precedence
     if solver_command and solver_command_source >= solver_source:
+        if solver_command_source == solver_source:
+            warn(
+                f"--solver-command and --solver are both provided at the same "
+                f"precedence level ({solver_source.name}), "
+                f"--solver-command will be used and --solver will be ignored",
+                allow_duplicate=False,
+            )
         return args
 
     # if no `--solver-command` is provided, or `--solver` has higher precedence,
@@ -1601,9 +1608,8 @@ def _main(_args=None) -> MainResult:
         else:
             error("flamegraph.pl not found in PATH")
             error("(see https://github.com/brendangregg/FlameGraph)")
-            args = args.with_overrides(
-                ConfigSource.dynamic_resolution, flamegraph=False
-            )
+            dynamic_resolution = ConfigSource.dynamic_resolution
+            args = args.with_overrides(dynamic_resolution, flamegraph=False)
 
     #
     # compile

--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -48,7 +48,13 @@ from .bytevec import ByteVec
 from .calldata import FunctionInfo, get_abi, mk_calldata
 from .cheatcodes import snapshot_state
 from .config import Config as HalmosConfig
-from .config import arg_parser, default_config, resolve_config_files, toml_parser
+from .config import (
+    ConfigSource,
+    arg_parser,
+    default_config,
+    resolve_config_files,
+    toml_parser,
+)
 from .constants import (
     VERBOSITY_TRACE_CONSTRUCTOR,
     VERBOSITY_TRACE_COUNTEREXAMPLE,
@@ -180,7 +186,8 @@ def with_devdoc(args: HalmosConfig, fn_sig: str, contract_json: dict) -> HalmosC
         return args
 
     overrides = arg_parser().parse_args(devdoc.split())
-    return args.with_overrides(source=fn_sig, **vars(overrides))
+    source = ConfigSource.function_annotation
+    return args.with_overrides(source, **vars(overrides))
 
 
 def with_natspec(
@@ -194,28 +201,25 @@ def with_natspec(
         return args
 
     overrides = arg_parser().parse_args(parsed.split())
-    return args.with_overrides(source=contract_name, **vars(overrides))
+    source = ConfigSource.contract_annotation
+    return args.with_overrides(source, **vars(overrides))
 
 
 def with_resolved_solver(args: HalmosConfig) -> HalmosConfig:
     solver, solver_source = args.value_with_source("solver")
     solver_command, solver_command_source = args.value_with_source("solver_command")
 
-    if solver_command:
-        if solver_source != "default":
-            sources = f"({solver_source=}, {solver_command_source=})"
-            raise RuntimeError(
-                f"can not provide both --solver-command and --solver {sources}"
-            )
-
-        # --solver-command is provided expliticly, it overrides the --solver default
+    # `--solver-command` overrides `--solver` if it is at least as high precedence
+    if solver_command and solver_command_source >= solver_source:
         return args
-    else:
-        # --solver is provided, so we need to resolve it to an actual command
-        command = get_solver_command(solver)
-        if not command:
-            raise RuntimeError(f"Solver '{solver}' could not be found or installed.")
-        return args.with_overrides(source="solver resolution", solver_command=command)
+
+    # if no `--solver-command` is provided, or `--solver` has higher precedence,
+    # we need to resolve `--solver <name>` to an actual command
+    command = get_solver_command(solver)
+    if not command:
+        raise RuntimeError(f"Solver '{solver}' could not be found or installed.")
+    source = ConfigSource.dynamic_resolution
+    return args.with_overrides(source, solver_command=command)
 
 
 def load_config(_args) -> HalmosConfig:
@@ -233,10 +237,12 @@ def load_config(_args) -> HalmosConfig:
             sys.exit(2)
 
         overrides = toml_parser().parse_file(config_file)
-        config = config.with_overrides(source=config_file, **overrides)
+        config_file = ConfigSource.config_file
+        config = config.with_overrides(config_file, **overrides)
 
     # finally apply the CLI overrides
-    config = config.with_overrides(source="command line args", **vars(cli_overrides))
+    command_line = ConfigSource.command_line
+    config = config.with_overrides(command_line, **vars(cli_overrides))
 
     return config
 
@@ -1595,7 +1601,9 @@ def _main(_args=None) -> MainResult:
         else:
             error("flamegraph.pl not found in PATH")
             error("(see https://github.com/brendangregg/FlameGraph)")
-            args = args.with_overrides("halmos runtime", flamegraph=False)
+            args = args.with_overrides(
+                ConfigSource.dynamic_resolution, flamegraph=False
+            )
 
     #
     # compile

--- a/src/halmos/config.py
+++ b/src/halmos/config.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Generator
 from dataclasses import MISSING, dataclass, fields
 from dataclasses import field as dataclass_field
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Any
 
 import toml
@@ -32,6 +32,26 @@ class TraceEvent(Enum):
     LOG = "LOG"
     SSTORE = "SSTORE"
     SLOAD = "SLOAD"
+
+
+class ConfigSource(IntEnum):
+    # default value, lowest precedence
+    default = 1
+
+    # e.g. halmos.toml
+    config_file = 2
+
+    # contract-level annotation (e.g. @custom:halmos --some-option)
+    contract_annotation = 3
+
+    # function-level annotation (e.g. @custom:halmos --some-option)
+    function_annotation = 4
+
+    # from command line
+    command_line = 5
+
+    # dynamic resolution (e.g. after solver resolution)
+    dynamic_resolution = 6
 
 
 # helper to define config fields
@@ -82,6 +102,15 @@ class ParseTimeout(argparse.Action):
     def parse(values: str) -> float:
         # keeping ms as the default unit for backward compatibility
         return parse_time(values, default_unit="ms")
+
+    @staticmethod
+    def unparse(value: float) -> str:
+        # less than 1s, render as ms
+        if value < 1:
+            return f"{int(value * 1000)}ms"
+
+        # otherwise, render as s
+        return f"{int(value)}s"
 
 
 class ParseCSVTraceEvent(argparse.Action):
@@ -195,7 +224,7 @@ class Config:
         },
     )
 
-    _source: str = dataclass_field(
+    _source: ConfigSource = dataclass_field(
         metadata={
             internal: True,
         },
@@ -617,7 +646,7 @@ class Config:
 
         return value
 
-    def with_overrides(self, source: str, **overrides):
+    def with_overrides(self, source: ConfigSource, **overrides):
         """Create a new configuration object with some fields overridden.
 
         Use vars(namespace) to pass in the arguments from an argparse parser or
@@ -630,7 +659,7 @@ class Config:
             warn(f"error: unrecognized argument: {str(e).split()[-1]}")
             sys.exit(2)
 
-    def value_with_source(self, name: str) -> tuple[Any, str]:
+    def value_with_source(self, name: str) -> tuple[Any, ConfigSource]:
         # look up value in current object
         value = object.__getattribute__(self, name)
         if value is not None:
@@ -643,7 +672,7 @@ class Config:
 
         return (value, self._source)
 
-    def values_with_sources(self) -> dict[str, tuple[Any, str]]:
+    def values_with_sources(self) -> dict[str, tuple[Any, ConfigSource]]:
         # field -> (value, source)
         values = {}
         for field in fields(self):
@@ -665,7 +694,7 @@ class Config:
 
             yield field.name, field_value
 
-    def values_by_layer(self) -> dict[str, tuple[str, Any]]:
+    def values_by_layer(self) -> dict[ConfigSource, dict[str, Any]]:
         # source -> {field, value}
         if self._parent is None:
             return OrderedDict([(self._source, dict(self.values()))])
@@ -677,7 +706,7 @@ class Config:
     def formatted_layers(self) -> str:
         lines = []
         for layer, values in self.values_by_layer().items():
-            lines.append(f"{layer}:")
+            lines.append(f"{layer.name}:")
             for field, value in values.items():
                 lines.append(f"  {field}: {value}")
         return "\n".join(lines)
@@ -717,15 +746,15 @@ class TomlParser:
 
     def parse_file(self, toml_file_path: str) -> dict:
         with open(toml_file_path) as f:
-            return self.parse_str(f.read(), source=toml_file_path)
+            return self.parse_str(f.read())
 
     # exposed for easier testing
-    def parse_str(self, file_contents: str, source: str = "halmos.toml") -> dict:
+    def parse_str(self, file_contents: str) -> dict:
         parsed = toml.loads(file_contents)
-        return self.parse_dict(parsed, source=source)
+        return self.parse_dict(parsed)
 
     # exposed for easier testing
-    def parse_dict(self, parsed: dict, source: str = "halmos.toml") -> dict:
+    def parse_dict(self, parsed: dict) -> dict:
         if len(parsed) != 1:
             warn(
                 f"error: expected a single `[global]` section in the toml file, "
@@ -772,7 +801,7 @@ def _create_default_config() -> "Config":
         action = field.metadata.get("action", None)
         values[field.name] = action.parse(raw_value) if action else raw_value
 
-    return Config(_parent=None, _source="default", **values)
+    return Config(_parent=None, _source=ConfigSource.default, **values)
 
 
 def _create_arg_parser() -> argparse.ArgumentParser:
@@ -867,7 +896,9 @@ def main():
         return str(value)
 
     args = arg_parser().parse_args()
-    config = default_config().with_overrides(source="command-line", **vars(args))
+    config = default_config().with_overrides(
+        source=ConfigSource.command_line, **vars(args)
+    )
 
     # devs can have a little easter egg
     lines = [
@@ -921,7 +952,7 @@ def main():
         # callable defaults mean that the default value is not a hardcoded constant
         # it depends on the context, so don't emit it in the config file unless it
         # is explicitly set by the user on the command line
-        if value is None or (callable(default) and source != "command-line"):
+        if value is None or (callable(default) and source != ConfigSource.command_line):
             metavar = field_info.metadata.get("metavar", None)
             lines.append(f"# {name} = {metavar}")
         else:

--- a/tests/regression/halmos.toml
+++ b/tests/regression/halmos.toml
@@ -27,6 +27,9 @@ match-test = ""
 # specify Panic error codes to be treated as test failures; use '*' to include all error codes
 panic-error-codes = "0x01"
 
+# set depth for invariant testing (length of the stateful sequence of calls)
+invariant-depth = 2
+
 # set loop unrolling bounds
 loop = 2
 
@@ -36,11 +39,15 @@ width = 0
 # set the maximum length in steps of a single path; 0 means unlimited
 depth = 0
 
-# set the length of dynamic-sized arrays including bytes and string (default: loop unrolling bound)
+# specify lengths for dynamic-sized arrays, bytes, and string types
+# Lengths can be specified as a comma-separated list of integers enclosed in curly braces, or as a single integer.
 array-lengths = ""
 
-# set the default length candidates for bytes and string not specified in --array-lengths
-default-bytes-lengths = "0,1024,65"
+# set default lengths for dynamic-sized arrays (excluding bytes and string) not specified in --array-lengths
+default-array-lengths = "0,1,2"
+
+# set default lengths for bytes and string types not specified in --array-lengths
+default-bytes-lengths = "0,65,1024"
 
 # Select one of the available storage layout models
 # The generic model should only be necessary for vyper, huff, or unconventional storage patterns in yul.
@@ -48,6 +55,9 @@ storage-layout = "solidity"
 
 # allow the usage of FFI to call external functions
 ffi = false
+
+# generate coverage report at the given file path (disabled by default)
+# coverage-output = COVERAGE_FILE_PATH
 
 ################################################################################
 #                              Debugging options                               #
@@ -59,11 +69,17 @@ verbose = 0
 # print statistics
 statistics = false
 
+# disable progress display
+no-status = false
+
 # run in debug mode
 debug = false
 
-# log every execution steps in JSON
-# log = LOG_FILE_PATH
+# debug config parsing (show all config values and their sources)
+debug-config = false
+
+# profile instruction execution frequencies
+profile-instructions = false
 
 # output test results in JSON
 # json-output = JSON_FILE_PATH
@@ -101,6 +117,16 @@ early-exit = false
 # dump SMT queries for assertion violations
 dump-smt-queries = false
 
+# disable Python's automatic garbage collection for cyclic objects
+# This does not affect reference counting based garbage collection.
+disable-gc = false
+
+# trace memory allocations and deallocations
+trace-memory = false
+
+# include specific events in traces
+trace-events = "LOG,SSTORE,SLOAD"
+
 ################################################################################
 #                                Build options                                 #
 ################################################################################
@@ -112,19 +138,28 @@ forge-build-out = "out"
 #                                Solver options                                #
 ################################################################################
 
+# specify the SMT solver to use
+# If not specified, defaults to 'yices'
+# If --solver-command is used, this is ignored.
+solver = "yices"
+
 # interpret constant power up to N
 smt-exp-by-const = 2
 
-# set timeout (in milliseconds) for solving branching conditions; 0 means no timeout
-solver-timeout-branching = 1
+# set timeout for solving branching conditions; 0 means no timeout
+# Can specify a unit, e.g
+# '200ms', '5s', '2m', '1h', etc.
+solver-timeout-branching = "1ms"
 
-# set timeout (in milliseconds) for solving assertion violation conditions; 0 means no timeout
-solver-timeout-assertion = 60000
+# set timeout for solving assertion violation conditions; 0 means no timeout
+# Can specify a unit, e.g
+# '200ms', '5s', '2m', '1h', etc.
+solver-timeout-assertion = "60s"
 
 # set memory limit (in megabytes) for the solver; 0 means no limit
 solver-max-memory = 0
 
-# use the given command when invoking the solver
+# use the given exact command when invoking the solver (overrides automatic solver detection/download triggered by --solver)
 # solver-command = COMMAND
 
 # set the number of threads for parallel solvers
@@ -139,3 +174,6 @@ cache-solver = false
 
 # support symbolic jump destination
 symbolic-jump = false
+
+# generate a flamegraph of the execution
+flamegraph = false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from halmos.config import (
     Config,
+    ConfigSource,
     ParseArrayLengths,
     ParseCSVInt,
     ParseErrorCodes,
@@ -314,3 +315,23 @@ def test_parse_array_lengths_roundtrip():
         unparsed = ParseArrayLengths.unparse(original)
         parsed = ParseArrayLengths.parse(unparsed)
         assert parsed == original, f"Roundtrip failed for {original}"
+
+
+def test_value_with_source(config):
+    assert config.value_with_source("solver_threads") == (
+        config.solver_threads,
+        ConfigSource.default,
+    )
+
+    overrides = {"solver_threads": 42}
+
+    config_from_args = config.with_overrides(
+        source=ConfigSource.command_line, **overrides
+    )
+
+    val, source = config_from_args.value_with_source("solver_threads")
+    assert val == 42
+    assert source == ConfigSource.command_line
+
+    # overrides have higher precedence than defaults
+    assert source > ConfigSource.default


### PR DESCRIPTION
fixes the annoying "can not provide both --solver-command and --solver" error