### PR TITLE
ci: remove solver timeout for long and ffi tests

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -30,4 +30,4 @@ jobs:
         run: docker run halmos-image halmos --version
 
       - name: Run pytest
-        run: docker run -v .:/workspace halmos-image pytest -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options="--ffi -v -st --solver-timeout-assertion 0"
+        run: docker run -v .:/workspace halmos-image pytest -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options="--ffi -v -st"

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          docker run -v .:/workspace halmos-image pytest -x -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options='-st --solver-timeout-assertion 0 --solver-threads 3 --solver-command yices-smt2 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}' -s --log-cli-level=
+          docker run -v .:/workspace halmos-image pytest -x -v tests/test_halmos.py -k ${{ matrix.testname }} --halmos-options='-st --solver-threads 3 ${{ matrix.cache-solver }} ${{ inputs.halmos-options }}' -s --log-cli-level=


### PR DESCRIPTION
updated ci scripts to work with #544

this fixes the ci failure: https://github.com/a16z/halmos/actions/runs/15693189652