### PR TITLE
Update setup-uv action to v6

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,7 +27,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           version: "0.5.21"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: forge --version
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           # Install a specific version of uv.
           version: "0.5.21"


### PR DESCRIPTION
This PR updates the astral-sh/setup-uv GitHub Action from version v4 to v6 in the workflow files .github/workflows/copilot-setup-steps.yml and .github/workflows/test.yml.
Confirmed using the [v6.3.1 release](https://github.com/astral-sh/setup-uv/releases/tag/v6.3.1).
No other changes were made.