### PR TITLE
temporarily avoid rich 14.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "toml>=0.10.2",
     "z3-solver==4.12.6.0",
     "eth_hash[pysha3]>=0.7.0",
-    "rich>=13.9.4",
+    "rich>=14.0.0,<14.1.0",
     "xxhash>=3.5.0",
     "psutil>=6.1.0",
     "requests>=2.32.3",


### PR DESCRIPTION
calling console.clear_live() results in `IndexError: pop from empty list` starting in 14.1.0: https://github.com/Textualize/rich/issues/3809