### PR TITLE
handle failed solver processes

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -1193,6 +1193,11 @@ def run_test(ctx: FunctionContext) -> TestResult:
             REVERT_ALL,
             f"{funsig}: all paths have been reverted; the setup state or inputs may have been too restrictive.",
         )
+    elif len(ctx.solver_outputs) < len(submitted_futures):
+        # some solver results are missing, likely due to exceptions.
+        # not an early exit, as counter["sat"] > 0 would have been handled earlier.
+        passfail = color_error("[ERROR]")
+        exitcode = Exitcode.EXCEPTION.value
     else:
         passfail = color_good("[PASS]")
         exitcode = Exitcode.PASS.value


### PR DESCRIPTION
when an exception is raised in solver subprocesses, their result may not be added to the solver_outputs list. in the current implementation, if all processes fail due to exceptions, it may incorrectly return pass because no error solver outputs are recorded.

this pr adds logic to detect such cases by comparing the number of solver outputs with the number of solver processes. the detection is designed to distinguish these from early exit scenarios.