### PR TITLE
avoid solver race conditions with a lock

### DIFF
--- a/src/halmos/solvers.py
+++ b/src/halmos/solvers.py
@@ -16,7 +16,7 @@ import requests
 
 from halmos.logs import debug, error
 from halmos.ui import ui
-from halmos.utils import format_size
+from halmos.utils import format_size, synchronized
 
 # not defaulting to latest because of https://github.com/a16z/halmos/issues/492
 DEFAULT_YICES_VERSION = "2.6.4"
@@ -475,6 +475,7 @@ def find_solver_binary(solver: SolverInfo) -> Path | None:
     return None
 
 
+@synchronized()
 def ensure_solver_available(solver: SolverInfo) -> Path:
     """
     Ensures the specified solver is available, downloading it if necessary.

--- a/src/halmos/utils.py
+++ b/src/halmos/utils.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import math
 import re
+import threading
 import uuid
-from functools import partial
+from functools import partial, wraps
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any, TypeAlias, Union
 
@@ -1237,6 +1238,23 @@ def timed(label=None):
                 result = func(*args, **kwargs)
 
             return result
+
+        return wrapper
+
+    return decorator
+
+
+def synchronized(lock=None):
+    """Decorator that synchronizes access to a method or function"""
+
+    def decorator(func):
+        # Create a lock for this specific function if none provided
+        func_lock = lock or threading.RLock()
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with func_lock:
+                return func(*args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
ideally we would solve this after parsing the command line and before entering tests, but unfortunately this approach does not work because solvers can be overridden at the test level. So we could analyze the config when it's created at the different levels (command line, contract, function...) but this seems overly complex, and we may also run contracts and tests concurrently in the future so this may break.

Instead let's use a simple lock on `ensure_solver_available`, captured in the Java-style `synchronized` decorator. This time the flow is that `ensure_solver_available` can only be entered by one thread at a time, therefore:
- the first time we find a missing solver, we start the download
- other concurrent queries are waiting
- once the download is finished and the command is resolved, the lock is released
- the concurrent queries get the resolved command, without having to trigger the download again

fixes https://github.com/a16z/halmos/issues/568