### PR TITLE
fix: immediately halt execution on assert(false)

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1385,6 +1385,17 @@ class Exec:  # an execution path
         if match_dynamic_array_overflow_condition(cond):
             return unsat
 
+        # Check if the condition or its negation is already present in the path constraints.
+        # This quick existence check can make a significant difference when dealing with
+        # complex path constraints, where the solver might return unknown (under the 1ms timeout)
+        # even if the result is trivially sat or unsat.
+
+        if cond in self.path.conditions:
+            return sat
+
+        if simplify(Not(cond)) in self.path.conditions:
+            return unsat
+
     def check(self, cond: Any) -> Any:
         cond = simplify(cond)
 

--- a/src/halmos/traces.py
+++ b/src/halmos/traces.py
@@ -186,7 +186,11 @@ def render_trace(context: CallContext, file=sys.stdout) -> None:
             # TODO: print in debug mode
             ...
 
-        initcode_str = f"<{byte_length(message.data)} bytes of initcode>" if context.depth > 1 else "constructor()"
+        initcode_str = (
+            f"<{byte_length(message.data)} bytes of initcode>"
+            if context.depth > 1
+            else "constructor()"
+        )
         print(
             f"{indent}{call_scheme_str}{addr_str}::{initcode_str}{value_str}", file=file
         )


### PR DESCRIPTION
fixes https://github.com/foundry-rs/forge-std/issues/705

previously, halmos didn't immediately halt execution for trivially false assertions, e.g., assert(false). this became problematic with the updated forge-std assertion logic (https://github.com/foundry-rs/forge-std/pull/693), as it led to path explosion in complex tests like snekmate.

this pr fixes the behavior: when an assertion condition is trivially unsat, its execution path is now halted immediately.