### PR TITLE
fix: shorten bytecode output in unknown deployed bytecode warning

### DIFF
--- a/src/halmos/sevm.py
+++ b/src/halmos/sevm.py
@@ -1703,7 +1703,9 @@ class Exec:  # an execution path
             contract_name, filename, source_map = self._try_resolve_proxy_info(contract)
 
         if contract_name is None:
-            warn(f"unknown deployed bytecode: {hexify(bytecode.unwrap())}")
+            warn(
+                f"unknown deployed bytecode: {hexify(bytecode[:32].unwrap())}... ({byte_length(bytecode)} bytes total)"
+            )
 
         contract.contract_name = contract_name
         contract.filename = filename


### PR DESCRIPTION
previously:

<img width="1596" height="805" alt="Screenshot 2025-08-04 at 5 18 31 PM" src="https://github.com/user-attachments/assets/0a6ac899-57ab-4d63-bfe2-37b8ddfc7d91" />

now:

<img width="888" height="40" alt="Screenshot 2025-08-04 at 5 19 15 PM" src="https://github.com/user-attachments/assets/a0d27a88-d98a-4e01-becf-e353a20bc501" />
