### PR TITLE
fix: symbolic storage variables in counterexample + add path id to co…

### DIFF
--- a/src/halmos/__main__.py
+++ b/src/halmos/__main__.py
@@ -949,7 +949,7 @@ class CounterexampleHandler:
             print(ctx.traces[path_id], end="")
 
         if model.is_valid:
-            print(color_error(f"Counterexample: {model}"))
+            print(color_error(f"Counterexample: [{path_id}] {model}"))
             ctx.valid_counterexamples.append(model)
 
             # add the stacks from the temporary flamegraph to the global one

--- a/src/halmos/solve.py
+++ b/src/halmos/solve.py
@@ -61,7 +61,7 @@ ModelVariables = dict[str, ModelVariable]
 halmos_var_pattern = re.compile(
     r"""
     \(\s*define-fun\s+               # Match "(define-fun"
-    \|?((?:halmos_|p_)[^ |]+)\|?\s+  # Capture either halmos_* or p_*, optionally wrapped in "|"
+    \|?((?:halmos_|p_)[^ |]+|storage_[^ |]+_00)\|?\s+  # Capture halmos_* or p_* or storage_*_00 optionally wrapped in "|"
     \(\)\s+\(_\s+([^ ]+)\s+          # Capture the SMTLIB type (e.g., "BitVec 256")
     (\d+)\)\s+                       # Capture the bit-width or type argument
     (                                # Group for the value


### PR DESCRIPTION
fixes #577 (only doesnt work for yices)
also includes path id in counterexample (for debug or advanced use cases)
<img width="884" height="163" alt="Screenshot 2025-09-12 at 11 56 12 PM" src="https://github.com/user-attachments/assets/2d3512fe-9f20-4044-aa40-6c795d6cad68" />
